### PR TITLE
Split disconnected home CTA labels

### DIFF
--- a/nym-vpn-apple/Home/Package.swift
+++ b/nym-vpn-apple/Home/Package.swift
@@ -61,7 +61,10 @@ let package = Package(
         ),
         .testTarget(
             name: "HomeTests",
-            dependencies: ["Home"]
+            dependencies: [
+                "Home",
+                .product(name: "AccountPrefetchGates", package: "Services")
+            ]
         )
     ]
 )

--- a/nym-vpn-apple/Home/Package.swift
+++ b/nym-vpn-apple/Home/Package.swift
@@ -63,7 +63,16 @@ let package = Package(
             name: "HomeTests",
             dependencies: [
                 "Home",
-                .product(name: "AccountPrefetchGates", package: "Services")
+                .product(name: "AccountPrefetchGates", package: "Services"),
+                .product(name: "Theme", package: "Theme"),
+                .product(name: "SnackbarManager", package: "Services"),
+                .product(name: "AppSettings", package: "Services"),
+                .product(name: "ConnectionManager", package: "Services"),
+                .product(name: "CredentialsManager", package: "Services"),
+                .product(name: "GatewayManager", package: "Services"),
+                .product(name: "ImpactGenerator", package: "Services"),
+                .product(name: "NetworkMonitor", package: "Services"),
+                .product(name: "GRPCManager", package: "ServicesMacOS", condition: .when(platforms: [.macOS]))
             ]
         )
     ]

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -140,6 +140,8 @@ import GRPCManager
         switch action {
         case .session(let event):
             handleSessionEvent(event)
+        case .requestWelcome:
+            requestWelcome()
         case .requestInactiveSubscriptionPurchase:
             requestInactiveSubscriptionPurchase()
         case .dismissPostPurchaseProcessing:
@@ -370,6 +372,12 @@ import GRPCManager
 
     func requestPlanPurchaseTransition() {
         handleSessionEvent(.requestPlanPurchase)
+    }
+
+    public func requestWelcome() {
+        path = NavigationPath()
+        pendingDrawerContent = .welcome
+        drawerContent = .welcome
     }
 
     public func requestInactiveSubscriptionPurchase() {

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -376,8 +376,7 @@ import GRPCManager
 
     public func requestWelcome() {
         path = NavigationPath()
-        pendingDrawerContent = .welcome
-        drawerContent = .welcome
+        stagePreauthDrawer(.welcome)
     }
 
     public func requestInactiveSubscriptionPurchase() {

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppSessionCoordinating.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppSessionCoordinating.swift
@@ -5,6 +5,7 @@ import AccountPrefetchGates
 /// imperative UI requests with side effects (sheets, task cancellation).
 public enum CoordinatorAction: Equatable, Sendable {
     case session(SessionEvent)
+    case requestWelcome
     case requestInactiveSubscriptionPurchase
     case dismissPostPurchaseProcessing
 }

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickModels.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickModels.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import AccountPrefetchGates
 import ConnectionTypes
 import Theme
 import UIComponents
@@ -11,7 +12,22 @@ public enum OneClickConnectState: Equatable {
     case connected
     case disconnecting
     case noInternet
+    case noAccount
     case noSubscription
+    case accountUnreachable
+
+    static func disconnected(_ cta: DisconnectedHomeCTA) -> Self {
+        switch cta {
+        case .getStarted:
+            .noAccount
+        case .choosePlan:
+            .noSubscription
+        case .accountUnreachable:
+            .accountUnreachable
+        case .connect:
+            .disconnected
+        }
+    }
 }
 
 public enum OneClickDisplayMode: String, Codable, Equatable, Sendable, CaseIterable {

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickModels.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickModels.swift
@@ -15,6 +15,7 @@ public enum OneClickConnectState: Equatable {
     case noAccount
     case noSubscription
     case accountUnreachable
+    case checkingAccount
 
     static func disconnected(_ cta: DisconnectedHomeCTA) -> Self {
         switch cta {
@@ -24,6 +25,8 @@ public enum OneClickConnectState: Equatable {
             .noSubscription
         case .accountUnreachable:
             .accountUnreachable
+        case .checking:
+            .checkingAccount
         case .connect:
             .disconnected
         }

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
@@ -319,6 +319,8 @@ private extension OneClickView {
             "purchasePlan.chooseMyPlan".localizedString
         case .accountUnreachable:
             "home.accountUnreachable".localizedString
+        case .checkingAccount:
+            "requestingZkNyms".localizedString
         }
     }
 
@@ -329,7 +331,7 @@ private extension OneClickView {
         switch viewModel.connectState {
         case .disconnected, .noAccount, .noSubscription, .accountUnreachable:
             return .primary
-        case .connecting, .disconnecting, .noInternet:
+        case .connecting, .disconnecting, .noInternet, .checkingAccount:
             return .connecting
         case .stop:
             return .destructive
@@ -343,7 +345,7 @@ private extension OneClickView {
             return true
         }
         switch viewModel.connectState {
-        case .connecting, .disconnecting, .noInternet:
+        case .connecting, .disconnecting, .noInternet, .checkingAccount:
             return true
         case .disconnected, .stop, .connected, .noAccount, .noSubscription, .accountUnreachable:
             return false

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
@@ -313,14 +313,18 @@ private extension OneClickView {
             "disconnecting".localizedString
         case .noInternet:
             "offline".localizedString
-        case .noSubscription:
+        case .noAccount:
             "home.getStarted".localizedString
+        case .noSubscription:
+            "purchasePlan.chooseMyPlan".localizedString
+        case .accountUnreachable:
+            "home.accountUnreachable".localizedString
         }
     }
 
     var connectButtonStyle: NymButton.Style {
         switch viewModel.connectState {
-        case .disconnected, .noSubscription:
+        case .disconnected, .noAccount, .noSubscription, .accountUnreachable:
             .primary
         case .connecting, .disconnecting, .noInternet:
             .connecting
@@ -335,7 +339,7 @@ private extension OneClickView {
         switch viewModel.connectState {
         case .connecting, .disconnecting, .noInternet:
             true
-        case .disconnected, .stop, .connected, .noSubscription:
+        case .disconnected, .stop, .connected, .noAccount, .noSubscription, .accountUnreachable:
             false
         }
     }

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
@@ -323,6 +323,9 @@ private extension OneClickView {
     }
 
     var connectButtonStyle: NymButton.Style {
+        if viewModel.isRefreshingAccountSummary {
+            return .connecting
+        }
         switch viewModel.connectState {
         case .disconnected, .noAccount, .noSubscription, .accountUnreachable:
             .primary
@@ -336,6 +339,9 @@ private extension OneClickView {
     }
 
     var connectButtonDisabled: Bool {
+        if viewModel.isRefreshingAccountSummary {
+            return true
+        }
         switch viewModel.connectState {
         case .connecting, .disconnecting, .noInternet:
             true

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickView.swift
@@ -328,13 +328,13 @@ private extension OneClickView {
         }
         switch viewModel.connectState {
         case .disconnected, .noAccount, .noSubscription, .accountUnreachable:
-            .primary
+            return .primary
         case .connecting, .disconnecting, .noInternet:
-            .connecting
+            return .connecting
         case .stop:
-            .destructive
+            return .destructive
         case .connected:
-            .connected
+            return .connected
         }
     }
 
@@ -344,9 +344,9 @@ private extension OneClickView {
         }
         switch viewModel.connectState {
         case .connecting, .disconnecting, .noInternet:
-            true
+            return true
         case .disconnected, .stop, .connected, .noAccount, .noSubscription, .accountUnreachable:
-            false
+            return false
         }
     }
 

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel+State.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel+State.swift
@@ -87,6 +87,20 @@ extension OneClickViewModel {
             }
             .store(in: &cancellables)
 
+        credentialsManager.$accountSummaryLastFetchFailed
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.recomputeConnectState()
+            }
+            .store(in: &cancellables)
+
+        appSettings.$isCredentialImportedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.recomputeConnectState()
+            }
+            .store(in: &cancellables)
+
         networkMonitor.$isAvailable
             .removeDuplicates()
             .dropFirst()
@@ -134,10 +148,14 @@ extension OneClickViewModel {
             if !networkMonitor.isAvailable {
                 return .noInternet
             }
-            if credentialsManager.isValidCredentialImported, !credentialsManager.isAccountActive() {
-                return .noSubscription
-            }
-            return .disconnected
+            return .disconnected(
+                DisconnectedHomeCTA.resolve(
+                    isCredentialImported: credentialsManager.isValidCredentialImported,
+                    accountSummaryLastFetchFailed: credentialsManager.accountSummaryLastFetchFailed,
+                    isAccountActive: credentialsManager.isAccountActive(),
+                    hasAccountSummary: credentialsManager.accountSummary != nil
+                )
+            )
         }
     }
 

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
@@ -13,6 +13,7 @@ import ImpactGenerator
 import NetworkMonitor
 import TunnelStatus
 import UIComponents
+import Theme
 #if os(macOS)
 import GRPCManager
 #endif
@@ -51,8 +52,10 @@ public final class OneClickViewModel {
 
     @ObservationIgnored var connectDisconnectTask: Task<Void, Never>?
     @ObservationIgnored var resolveTask: Task<Void, Never>?
+    @ObservationIgnored var accountSummaryRefreshTask: Task<Void, Never>?
     @ObservationIgnored var cancellables = Set<AnyCancellable>()
     @ObservationIgnored var isConnectDisconnectInFlight = false
+    var isRefreshingAccountSummary = false
 
 #if os(iOS)
     public init(
@@ -111,7 +114,7 @@ public final class OneClickViewModel {
 #endif
 
     func connectButtonTapped() {
-        guard !isConnectDisconnectInFlight else { return }
+        guard !isConnectDisconnectInFlight, !isRefreshingAccountSummary else { return }
         guard connectionManager.currentTunnelStatus != .disconnecting else { return }
 
         impactGenerator.impact()
@@ -138,13 +141,42 @@ public final class OneClickViewModel {
             sessionCoordinator?.handle(.requestInactiveSubscriptionPurchase)
             return true
         case .accountUnreachable:
-            Task { @MainActor [weak self] in
-                await self?.credentialsManager.updateAccountSummary(force: true)
-            }
+            startAccountUnreachableRefresh()
             return true
         case .disconnected, .connecting, .stop, .connected, .disconnecting, .noInternet:
             return false
         }
+    }
+
+    func startAccountUnreachableRefresh() {
+        guard !isRefreshingAccountSummary else { return }
+        isRefreshingAccountSummary = true
+        accountSummaryRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                isRefreshingAccountSummary = false
+                accountSummaryRefreshTask = nil
+            }
+            await credentialsManager.updateAccountSummary(force: true)
+            if credentialsManager.accountSummaryLastFetchFailed {
+                presentAccountUnreachableRetryFailed()
+            }
+        }
+    }
+
+    func presentAccountUnreachableRetryFailed() {
+        snackbarManager.enqueue(
+            SnackbarItem(
+                style: .critical,
+                title: "home.accountUnreachable".localizedString,
+                message: "error.unexpected".localizedString,
+                actionTitle: "retry".localizedString,
+                onAction: { [weak self] in
+                    self?.snackbarManager.clear()
+                    _ = self?.handleDisconnectedHomeCTATap()
+                }
+            )
+        )
     }
 
     func disconnectFromError() {

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
@@ -117,11 +117,33 @@ public final class OneClickViewModel {
         impactGenerator.impact()
         snackbarManager.clear()
 
+        if handleDisconnectedHomeCTATap() {
+            return
+        }
+
         let isConnectingTap = connectionManager.currentTunnelStatus != .connected
 
         connectDisconnectTask?.cancel()
         connectDisconnectTask = Task { @MainActor [weak self] in
             await self?.performConnectDisconnect(isConnectingTap: isConnectingTap)
+        }
+    }
+
+    func handleDisconnectedHomeCTATap() -> Bool {
+        switch connectState {
+        case .noAccount:
+            sessionCoordinator?.handle(.requestWelcome)
+            return true
+        case .noSubscription:
+            sessionCoordinator?.handle(.requestInactiveSubscriptionPurchase)
+            return true
+        case .accountUnreachable:
+            Task { @MainActor [weak self] in
+                await self?.credentialsManager.updateAccountSummary(force: true)
+            }
+            return true
+        case .disconnected, .connecting, .stop, .connected, .disconnecting, .noInternet:
+            return false
         }
     }
 
@@ -208,7 +230,6 @@ public final class OneClickViewModel {
             }
         }
     }
-
 }
 
 extension OneClickSpeedMode {

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
@@ -143,6 +143,8 @@ public final class OneClickViewModel {
         case .accountUnreachable:
             startAccountUnreachableRefresh()
             return true
+        case .checkingAccount:
+            return true
         case .disconnected, .connecting, .stop, .connected, .disconnecting, .noInternet:
             return false
         }

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -177,6 +177,10 @@ public final class ProcessingAccountViewModel {
             syncProgressStep()
         }
         try Task.checkCancellation()
+<<<<<<< Updated upstream
+=======
+        return isActive
+>>>>>>> Stashed changes
     }
 
     private func applyBackendAccountPhase(

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -177,10 +177,6 @@ public final class ProcessingAccountViewModel {
             syncProgressStep()
         }
         try Task.checkCancellation()
-<<<<<<< Updated upstream
-=======
-        return isActive
->>>>>>> Stashed changes
     }
 
     private func applyBackendAccountPhase(

--- a/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelSubscriptionPurchaseTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelSubscriptionPurchaseTests.swift
@@ -35,6 +35,15 @@ final class AppFeatureViewModelSubscriptionPurchaseTests: XCTestCase {
 #endif
     }
 
+    func testRequestWelcomeOpensWelcomeDrawer() {
+        let viewModel = makeViewModel()
+        viewModel.drawerContent = .oneClick
+
+        viewModel.handle(.requestWelcome)
+
+        XCTAssertEqual(viewModel.drawerContent, .welcome)
+    }
+
 #if os(iOS)
     func testRequestInactiveSubscriptionPurchaseRoutesDirectlyToIAP() {
         let viewModel = makeViewModel()

--- a/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelSubscriptionPurchaseTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelSubscriptionPurchaseTests.swift
@@ -41,7 +41,13 @@ final class AppFeatureViewModelSubscriptionPurchaseTests: XCTestCase {
 
         viewModel.handle(.requestWelcome)
 
+        XCTAssertEqual(viewModel.pendingDrawerContent, .welcome)
+        XCTAssertEqual(viewModel.drawerContent, .oneClick)
+
+        viewModel.drawerTransitionCompleted()
+
         XCTAssertEqual(viewModel.drawerContent, .welcome)
+        XCTAssertNil(viewModel.pendingDrawerContent)
     }
 
 #if os(iOS)

--- a/nym-vpn-apple/Home/Tests/HomeTests/OneClickConnectStateCTATests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/OneClickConnectStateCTATests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Home
+import AccountPrefetchGates
+
+final class OneClickConnectStateCTATests: XCTestCase {
+    func testDisconnectedCTAMapsToNamedConnectStates() {
+        XCTAssertEqual(OneClickConnectState.disconnected(.getStarted), .noAccount)
+        XCTAssertEqual(OneClickConnectState.disconnected(.choosePlan), .noSubscription)
+        XCTAssertEqual(OneClickConnectState.disconnected(.accountUnreachable), .accountUnreachable)
+        XCTAssertEqual(OneClickConnectState.disconnected(.connect), .disconnected)
+    }
+}

--- a/nym-vpn-apple/Home/Tests/HomeTests/OneClickConnectStateCTATests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/OneClickConnectStateCTATests.swift
@@ -7,6 +7,7 @@ final class OneClickConnectStateCTATests: XCTestCase {
         XCTAssertEqual(OneClickConnectState.disconnected(.getStarted), .noAccount)
         XCTAssertEqual(OneClickConnectState.disconnected(.choosePlan), .noSubscription)
         XCTAssertEqual(OneClickConnectState.disconnected(.accountUnreachable), .accountUnreachable)
+        XCTAssertEqual(OneClickConnectState.disconnected(.checking), .checkingAccount)
         XCTAssertEqual(OneClickConnectState.disconnected(.connect), .disconnected)
     }
 }

--- a/nym-vpn-apple/Home/Tests/HomeTests/OneClickViewModelCTATapTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/OneClickViewModelCTATapTests.swift
@@ -78,6 +78,16 @@ final class OneClickViewModelCTATapTests: XCTestCase {
         XCTAssertEqual(spy.actions, [.requestInactiveSubscriptionPurchase])
     }
 
+    func testCheckingAccountTapDoesNotRouteCoordinatorOrConnect() {
+        let viewModel = makeViewModel()
+        let spy = SessionCoordinatorSpy()
+        viewModel.sessionCoordinator = spy
+        viewModel.connectState = .checkingAccount
+
+        XCTAssertTrue(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertTrue(spy.actions.isEmpty)
+    }
+
     func testDisconnectedTapDoesNotRouteCoordinator() {
         let viewModel = makeViewModel()
         let spy = SessionCoordinatorSpy()

--- a/nym-vpn-apple/Home/Tests/HomeTests/OneClickViewModelCTATapTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/OneClickViewModelCTATapTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import Home
+import AppSettings
+import ConnectionManager
+import CredentialsManager
+import GatewayManager
+import ImpactGenerator
+import NetworkMonitor
+import SnackbarManager
+import Theme
+
+@MainActor
+private final class SessionCoordinatorSpy: AppSessionCoordinating {
+    private(set) var actions: [CoordinatorAction] = []
+
+    func handle(_ action: CoordinatorAction) {
+        actions.append(action)
+    }
+}
+
+@MainActor
+final class OneClickViewModelCTATapTests: XCTestCase {
+    private var snackbarManager: SnackbarManager!
+
+    override func setUp() {
+        super.setUp()
+        snackbarManager = SnackbarManager()
+    }
+
+    override func tearDown() {
+        snackbarManager.clear()
+        snackbarManager = nil
+        super.tearDown()
+    }
+
+    private func makeViewModel() -> OneClickViewModel {
+#if os(iOS)
+        OneClickViewModel(
+            appSettings: .shared,
+            connectionManager: .shared,
+            credentialsManager: .shared,
+            gatewayManager: .shared,
+            snackbarManager: snackbarManager,
+            impactGenerator: .shared,
+            networkMonitor: .shared
+        )
+#elseif os(macOS)
+        OneClickViewModel(
+            appSettings: .shared,
+            connectionManager: .shared,
+            credentialsManager: .shared,
+            gatewayManager: .shared,
+            snackbarManager: snackbarManager,
+            impactGenerator: .shared,
+            networkMonitor: .shared,
+            grpcManager: .shared
+        )
+#endif
+    }
+
+    func testNoAccountTapRequestsWelcome() {
+        let viewModel = makeViewModel()
+        let spy = SessionCoordinatorSpy()
+        viewModel.sessionCoordinator = spy
+        viewModel.connectState = .noAccount
+
+        XCTAssertTrue(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertEqual(spy.actions, [.requestWelcome])
+    }
+
+    func testNoSubscriptionTapRequestsPlanPurchase() {
+        let viewModel = makeViewModel()
+        let spy = SessionCoordinatorSpy()
+        viewModel.sessionCoordinator = spy
+        viewModel.connectState = .noSubscription
+
+        XCTAssertTrue(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertEqual(spy.actions, [.requestInactiveSubscriptionPurchase])
+    }
+
+    func testDisconnectedTapDoesNotRouteCoordinator() {
+        let viewModel = makeViewModel()
+        let spy = SessionCoordinatorSpy()
+        viewModel.sessionCoordinator = spy
+        viewModel.connectState = .disconnected
+
+        XCTAssertFalse(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertTrue(spy.actions.isEmpty)
+    }
+
+    func testAccountUnreachableTapStartsRefreshAndIgnoresReentry() async {
+        let viewModel = makeViewModel()
+        let spy = SessionCoordinatorSpy()
+        viewModel.sessionCoordinator = spy
+        viewModel.connectState = .accountUnreachable
+
+        XCTAssertTrue(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertTrue(viewModel.isRefreshingAccountSummary)
+        XCTAssertNotNil(viewModel.accountSummaryRefreshTask)
+        XCTAssertTrue(spy.actions.isEmpty)
+
+        XCTAssertTrue(viewModel.handleDisconnectedHomeCTATap())
+        XCTAssertTrue(viewModel.isRefreshingAccountSummary)
+        XCTAssertTrue(spy.actions.isEmpty)
+
+        await viewModel.accountSummaryRefreshTask?.value
+        XCTAssertFalse(viewModel.isRefreshingAccountSummary)
+    }
+
+    func testAccountUnreachableRetryFailedShowsSnackbarWithRetry() async {
+        let viewModel = makeViewModel()
+        viewModel.connectState = .accountUnreachable
+
+        viewModel.presentAccountUnreachableRetryFailed()
+
+        XCTAssertEqual(snackbarManager.current?.title, "home.accountUnreachable".localizedString)
+        XCTAssertEqual(snackbarManager.current?.message, "error.unexpected".localizedString)
+        XCTAssertEqual(snackbarManager.current?.actionTitle, "retry".localizedString)
+
+        snackbarManager.current?.onAction?()
+        XCTAssertTrue(viewModel.isRefreshingAccountSummary)
+        viewModel.accountSummaryRefreshTask?.cancel()
+        await viewModel.accountSummaryRefreshTask?.value
+    }
+}

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -25,6 +25,7 @@ final class FakeProcessing: AccountProcessing {
     var storeDeeplinkError: Error?
     var registerError: Error?
     var accountActive = true
+    var becomesActiveAfterSync = false
     var prefetchDelay: Duration = .zero
     var prefetchResult: ZkNymPrefetchResult = .fetchedTickets
     private(set) var calls: [Call] = []
@@ -57,6 +58,9 @@ final class FakeProcessing: AccountProcessing {
 
     func updateAccountSummary(force: Bool, untilActive: Bool) async {
         calls.append(.sync)
+        if becomesActiveAfterSync {
+            accountActive = true
+        }
     }
 
     func isAccountActive() -> Bool {
@@ -142,7 +146,16 @@ struct ProcessingAccountViewModelTests {
 
         await viewModel.run()
 
+<<<<<<< Updated upstream
         #expect(processing.calls == [.ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch])
+=======
+        #expect(
+            processing.calls == [
+                .ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch
+            ]
+        )
+        #expect(processing.lastSyncUntilActive == false)
+>>>>>>> Stashed changes
         await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
@@ -286,6 +299,50 @@ struct ProcessingAccountViewModelTests {
         await finishSetupCarousel(viewModel)
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.phase == .finished)
+<<<<<<< Updated upstream
+=======
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func inactiveLoginSkipsSetupCarousel() async {
+        let processing = FakeProcessing()
+        processing.accountActive = false
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+        #expect(viewModel.usesStaticCopy)
+        #expect(processing.lastSyncUntilActive == false)
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func staleInactiveCacheDoesNotSkipCarouselUntilAfterSync() async {
+        let processing = FakeProcessing()
+        processing.accountActive = false
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        #expect(!viewModel.usesStaticCopy)
+        #expect(ProcessingUIPolicy.showsOnboardingProgressBar(usesStaticCopy: viewModel.usesStaticCopy))
+
+        await viewModel.run()
+
+        #expect(viewModel.usesStaticCopy)
+        #expect(viewModel.phase == .finished)
+    }
+
+    @Test func staleInactiveCacheDoesNotFlipStaticCopyWhenSyncActivates() async {
+        let processing = FakeProcessing()
+        processing.accountActive = false
+        processing.becomesActiveAfterSync = true
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        #expect(!viewModel.usesStaticCopy)
+        await viewModel.run()
+        #expect(!viewModel.usesStaticCopy)
+>>>>>>> Stashed changes
     }
 
     @Test func navigationWaitsForCarouselAfterWorkCompletes() async {

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -146,16 +146,7 @@ struct ProcessingAccountViewModelTests {
 
         await viewModel.run()
 
-<<<<<<< Updated upstream
         #expect(processing.calls == [.ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch])
-=======
-        #expect(
-            processing.calls == [
-                .ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch
-            ]
-        )
-        #expect(processing.lastSyncUntilActive == false)
->>>>>>> Stashed changes
         await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
@@ -299,50 +290,7 @@ struct ProcessingAccountViewModelTests {
         await finishSetupCarousel(viewModel)
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.phase == .finished)
-<<<<<<< Updated upstream
-=======
         #expect(coordinator.actions == [.session(.processingFinished)])
-    }
-
-    @Test func inactiveLoginSkipsSetupCarousel() async {
-        let processing = FakeProcessing()
-        processing.accountActive = false
-        let coordinator = FakeCoordinator()
-        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
-
-        await viewModel.run()
-        #expect(viewModel.usesStaticCopy)
-        #expect(processing.lastSyncUntilActive == false)
-        #expect(viewModel.phase == .finished)
-        #expect(coordinator.actions == [.session(.processingFinished)])
-    }
-
-    @Test func staleInactiveCacheDoesNotSkipCarouselUntilAfterSync() async {
-        let processing = FakeProcessing()
-        processing.accountActive = false
-        let coordinator = FakeCoordinator()
-        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
-
-        #expect(!viewModel.usesStaticCopy)
-        #expect(ProcessingUIPolicy.showsOnboardingProgressBar(usesStaticCopy: viewModel.usesStaticCopy))
-
-        await viewModel.run()
-
-        #expect(viewModel.usesStaticCopy)
-        #expect(viewModel.phase == .finished)
-    }
-
-    @Test func staleInactiveCacheDoesNotFlipStaticCopyWhenSyncActivates() async {
-        let processing = FakeProcessing()
-        processing.accountActive = false
-        processing.becomesActiveAfterSync = true
-        let coordinator = FakeCoordinator()
-        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
-
-        #expect(!viewModel.usesStaticCopy)
-        await viewModel.run()
-        #expect(!viewModel.usesStaticCopy)
->>>>>>> Stashed changes
     }
 
     @Test func navigationWaitsForCarouselAfterWorkCompletes() async {

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -16504,6 +16504,17 @@
         }
       }
     },
+    "home.accountUnreachable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't reach account"
+          }
+        }
+      }
+    },
     "home.installDaemon" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
+++ b/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
@@ -222,11 +222,30 @@ private extension NymVPNDaemonApp {
         .menuBarExtraStyle(.menu)
         .onChange(of: connectionManager.currentTunnelStatus) { _, status in
             updateImageName(with: status)
-            menuBarConnectButtonState = ConnectButtonState(
-                tunnelStatus: status,
-                isCredentialImported: credentialsManager.isValidCredentialImported
-            )
+            refreshMenuBarConnectButtonState()
         }
+        .onChange(of: appSettings.isCredentialImportedPublisher) { _, _ in
+            refreshMenuBarConnectButtonState()
+        }
+        .onChange(of: credentialsManager.accountSummaryLastFetchFailed) { _, _ in
+            refreshMenuBarConnectButtonState()
+        }
+        .onChange(of: credentialsManager.accountSummary) { _, _ in
+            refreshMenuBarConnectButtonState()
+        }
+        .onAppear {
+            refreshMenuBarConnectButtonState()
+        }
+    }
+
+    func refreshMenuBarConnectButtonState() {
+        menuBarConnectButtonState = ConnectButtonState(
+            tunnelStatus: connectionManager.currentTunnelStatus,
+            isCredentialImported: credentialsManager.isValidCredentialImported,
+            accountSummaryLastFetchFailed: credentialsManager.accountSummaryLastFetchFailed,
+            isAccountActive: credentialsManager.isAccountActive(),
+            hasAccountSummary: credentialsManager.accountSummary != nil
+        )
     }
 
     func closeWindow() {

--- a/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
+++ b/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
@@ -220,7 +220,7 @@ private extension NymVPNDaemonApp {
             Image(nsImage: menuBarNSImage)
         }
         .menuBarExtraStyle(.menu)
-        .onChange(of: connectionManager.currentTunnelStatus) { _, status in
+        .onChange(of: connectionManager.currentTunnelStatus, initial: true) { _, status in
             updateImageName(with: status)
             refreshMenuBarConnectButtonState()
         }
@@ -230,10 +230,7 @@ private extension NymVPNDaemonApp {
         .onChange(of: credentialsManager.accountSummaryLastFetchFailed) { _, _ in
             refreshMenuBarConnectButtonState()
         }
-        .onChange(of: credentialsManager.accountSummary) { _, _ in
-            refreshMenuBarConnectButtonState()
-        }
-        .onAppear {
+        .onChange(of: credentialsManager.accountSummary?.isActive) { _, _ in
             refreshMenuBarConnectButtonState()
         }
     }

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/DisconnectedHomeCTA.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/DisconnectedHomeCTA.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Disconnected home-button intent. Not a Policy type; labels and taps share this split.
+public enum DisconnectedHomeCTA: Equatable, Sendable {
+    case getStarted
+    case choosePlan
+    case accountUnreachable
+    case connect
+
+    public static func resolve(
+        isCredentialImported: Bool,
+        accountSummaryLastFetchFailed: Bool,
+        isAccountActive: Bool,
+        hasAccountSummary: Bool
+    ) -> Self {
+        if !isCredentialImported {
+            return .getStarted
+        }
+        if accountSummaryLastFetchFailed, !isAccountActive {
+            return .accountUnreachable
+        }
+        if !isAccountActive, hasAccountSummary {
+            return .choosePlan
+        }
+        return .connect
+    }
+}

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/DisconnectedHomeCTA.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/DisconnectedHomeCTA.swift
@@ -5,6 +5,7 @@ public enum DisconnectedHomeCTA: Equatable, Sendable {
     case getStarted
     case choosePlan
     case accountUnreachable
+    case checking
     case connect
 
     public static func resolve(
@@ -19,8 +20,8 @@ public enum DisconnectedHomeCTA: Equatable, Sendable {
         if accountSummaryLastFetchFailed, !isAccountActive {
             return .accountUnreachable
         }
-        if !isAccountActive, hasAccountSummary {
-            return .choosePlan
+        if !isAccountActive {
+            return hasAccountSummary ? .choosePlan : .checking
         }
         return .connect
     }

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/DisconnectedHomeCTATests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/DisconnectedHomeCTATests.swift
@@ -58,14 +58,14 @@ struct DisconnectedHomeCTATests {
         )
     }
 
-    @Test func importedWithoutSummaryIsConnectNotGetStarted() {
+    @Test func importedWithoutSummaryIsUnknownNotConnect() {
         #expect(
             DisconnectedHomeCTA.resolve(
                 isCredentialImported: true,
                 accountSummaryLastFetchFailed: false,
                 isAccountActive: false,
                 hasAccountSummary: false
-            ) == .connect
+            ) == .checking
         )
     }
 }

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/DisconnectedHomeCTATests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/DisconnectedHomeCTATests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+import AccountPrefetchGates
+
+struct DisconnectedHomeCTATests {
+    @Test func missingCredentialIsGetStarted() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: false,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: false,
+                hasAccountSummary: false
+            ) == .getStarted
+        )
+    }
+
+    @Test func inactiveSummaryIsChoosePlan() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: false,
+                hasAccountSummary: true
+            ) == .choosePlan
+        )
+    }
+
+    @Test func fetchFailedWithoutActiveAccountIsUnreachable() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: true,
+                isAccountActive: false,
+                hasAccountSummary: false
+            ) == .accountUnreachable
+        )
+    }
+
+    @Test func transientFetchFailedDoesNotOfferPlan() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: true,
+                isAccountActive: false,
+                hasAccountSummary: true
+            ) == .accountUnreachable
+        )
+    }
+
+    @Test func importedActiveIsConnect() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: true,
+                hasAccountSummary: true
+            ) == .connect
+        )
+    }
+
+    @Test func importedWithoutSummaryIsConnectNotGetStarted() {
+        #expect(
+            DisconnectedHomeCTA.resolve(
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: false,
+                hasAccountSummary: false
+            ) == .connect
+        )
+    }
+}

--- a/nym-vpn-apple/UIComponents/Package.swift
+++ b/nym-vpn-apple/UIComponents/Package.swift
@@ -33,6 +33,8 @@ let package = Package(
                 .product(name: "ConfigurationManager", package: "Services"),
                 .product(name: "ConnectionTypes", package: "ServicesMutual"),
                 .product(name: "Constants", package: "ServicesMutual"),
+                .product(name: "TunnelStatus", package: "ServicesMutual"),
+                .product(name: "AccountPrefetchGates", package: "Services"),
                 .product(name: "FeatureFlagsManager", package: "Services"),
                 .product(name: "Device", package: "Services"),
                 .product(name: "ImpactGenerator", package: "Services"),
@@ -47,7 +49,10 @@ let package = Package(
         ),
         .testTarget(
             name: "UIComponentsTests",
-            dependencies: ["UIComponents"]
+            dependencies: [
+                "UIComponents",
+                .product(name: "TunnelStatus", package: "ServicesMutual")
+            ]
         )
     ]
 )

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Buttons/ConnectButton/ConnectButtonState.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Buttons/ConnectButton/ConnectButtonState.swift
@@ -14,6 +14,7 @@ public enum ConnectButtonState: Equatable {
     case noAccount
     case noSubscription
     case accountUnreachable
+    case checkingAccount
 
     public init(
         tunnelStatus: TunnelStatus,
@@ -44,6 +45,8 @@ public enum ConnectButtonState: Equatable {
                 self = .noSubscription
             case .accountUnreachable:
                 self = .accountUnreachable
+            case .checking:
+                self = .checkingAccount
             case .connect:
                 self = .connect
             }
@@ -76,6 +79,8 @@ public enum ConnectButtonState: Equatable {
             "purchasePlan.chooseMyPlan".localizedString
         case .accountUnreachable:
             "home.accountUnreachable".localizedString
+        case .checkingAccount:
+            "requestingZkNyms".localizedString
         }
     }
 
@@ -83,7 +88,7 @@ public enum ConnectButtonState: Equatable {
         switch self {
         case .connect, .noInternet, .noAccount, .noSubscription, .accountUnreachable:
             NymColor.accent
-        case .installingDaemon, .noInternetReconnect:
+        case .installingDaemon, .noInternetReconnect, .checkingAccount:
             NymColor.gray1
         case .stop, .disconnecting, .disconnect:
             NymColor.error
@@ -97,7 +102,7 @@ extension ConnectButtonState {
         switch self {
         case .connect, .disconnect, .stop, .noInternetReconnect, .noInternet:
             true
-        case .disconnecting, .installingDaemon, .noAccount, .noSubscription, .accountUnreachable:
+        case .disconnecting, .installingDaemon, .noAccount, .noSubscription, .accountUnreachable, .checkingAccount:
             false
         }
     }

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Buttons/ConnectButton/ConnectButtonState.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Buttons/ConnectButton/ConnectButtonState.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import AccountPrefetchGates
 import Theme
 import TunnelStatus
 
-public enum ConnectButtonState {
+public enum ConnectButtonState: Equatable {
     case connect
     case disconnect
     case disconnecting
@@ -12,8 +13,15 @@ public enum ConnectButtonState {
     case noInternetReconnect
     case noAccount
     case noSubscription
+    case accountUnreachable
 
-    public init(tunnelStatus: TunnelStatus, isCredentialImported: Bool) {
+    public init(
+        tunnelStatus: TunnelStatus,
+        isCredentialImported: Bool,
+        accountSummaryLastFetchFailed: Bool = false,
+        isAccountActive: Bool = true,
+        hasAccountSummary: Bool = false
+    ) {
         if isCredentialImported == false {
             self = .noAccount
             return
@@ -24,7 +32,21 @@ public enum ConnectButtonState {
         case .connecting, .reasserting, .restarting:
             self = .stop
         case .disconnected:
-            self = .connect
+            switch DisconnectedHomeCTA.resolve(
+                isCredentialImported: isCredentialImported,
+                accountSummaryLastFetchFailed: accountSummaryLastFetchFailed,
+                isAccountActive: isAccountActive,
+                hasAccountSummary: hasAccountSummary
+            ) {
+            case .getStarted:
+                self = .noAccount
+            case .choosePlan:
+                self = .noSubscription
+            case .accountUnreachable:
+                self = .accountUnreachable
+            case .connect:
+                self = .connect
+            }
         case .disconnecting:
             self = .disconnecting
         case .offline, .unknown:
@@ -48,14 +70,18 @@ public enum ConnectButtonState {
             "stop".localizedString
         case .installingDaemon:
             "home.installDaemonButton".localizedString
-        case .noAccount, .noSubscription:
+        case .noAccount:
             "home.getStarted".localizedString
+        case .noSubscription:
+            "purchasePlan.chooseMyPlan".localizedString
+        case .accountUnreachable:
+            "home.accountUnreachable".localizedString
         }
     }
 
     var backgroundColor: Color {
         switch self {
-        case .connect, .noInternet, .noAccount, .noSubscription:
+        case .connect, .noInternet, .noAccount, .noSubscription, .accountUnreachable:
             NymColor.accent
         case .installingDaemon, .noInternetReconnect:
             NymColor.gray1
@@ -69,9 +95,9 @@ public enum ConnectButtonState {
 extension ConnectButtonState {
     public var menuBarItemIsAction: Bool {
         switch self {
-        case .connect, .disconnect, .stop, .noInternetReconnect, .noInternet, .noAccount, .noSubscription:
+        case .connect, .disconnect, .stop, .noInternetReconnect, .noInternet:
             true
-        case .disconnecting, .installingDaemon:
+        case .disconnecting, .installingDaemon, .noAccount, .noSubscription, .accountUnreachable:
             false
         }
     }

--- a/nym-vpn-apple/UIComponents/Tests/UIComponentsTests/ConnectButtonStateCTATests.swift
+++ b/nym-vpn-apple/UIComponents/Tests/UIComponentsTests/ConnectButtonStateCTATests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import UIComponents
+import TunnelStatus
+
+struct ConnectButtonStateCTATests {
+    @Test func missingCredentialIsNoAccount() {
+        #expect(
+            ConnectButtonState(
+                tunnelStatus: .disconnected,
+                isCredentialImported: false
+            ) == .noAccount
+        )
+    }
+
+    @Test func inactiveSummaryIsNoSubscription() {
+        #expect(
+            ConnectButtonState(
+                tunnelStatus: .disconnected,
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: false,
+                hasAccountSummary: true
+            ) == .noSubscription
+        )
+    }
+
+    @Test func fetchFailedIsAccountUnreachableNotConnect() {
+        #expect(
+            ConnectButtonState(
+                tunnelStatus: .disconnected,
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: true,
+                isAccountActive: false,
+                hasAccountSummary: false
+            ) == .accountUnreachable
+        )
+    }
+
+    @Test func activeAccountIsConnect() {
+        #expect(
+            ConnectButtonState(
+                tunnelStatus: .disconnected,
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: true,
+                hasAccountSummary: true
+            ) == .connect
+        )
+    }
+}

--- a/nym-vpn-apple/UIComponents/Tests/UIComponentsTests/ConnectButtonStateCTATests.swift
+++ b/nym-vpn-apple/UIComponents/Tests/UIComponentsTests/ConnectButtonStateCTATests.swift
@@ -36,6 +36,18 @@ struct ConnectButtonStateCTATests {
         )
     }
 
+    @Test func importedWithoutSummaryIsCheckingAccount() {
+        #expect(
+            ConnectButtonState(
+                tunnelStatus: .disconnected,
+                isCredentialImported: true,
+                accountSummaryLastFetchFailed: false,
+                isAccountActive: false,
+                hasAccountSummary: false
+            ) == .checkingAccount
+        )
+    }
+
     @Test func activeAccountIsConnect() {
         #expect(
             ConnectButtonState(


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1764](https://nymtech.atlassian.net/browse/NYM-1764)

Home connect label should match account state instead of always saying Connect or Get started.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6247)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connect buttons now reflect account status, including missing accounts, unavailable accounts, and account-summary checks.
  - Added clearer actions for getting started, choosing a plan, connecting, and retrying when an account cannot be reached.
  - Account-summary refreshes now provide progress feedback and a retry notification when unsuccessful.
  - Added support for opening the Welcome drawer through coordinator actions.
- **Bug Fixes**
  - Menu bar connection status now updates when account, credential, or tunnel information changes.
  - Updated labels and localized messaging for account-related connection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->