### PR TITLE
fix(android): disable Sentry Session Replay to stop foreground ANR kills

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
@@ -251,19 +251,25 @@ class NymVpn : Application() {
 				"https://cf027ef57330e976438c2cbbe1903868@o967446.ingest.us.sentry.io/4506859434082304"
 
 			val sampleRate: Double
-			val sessionSampleRate: Double
+			val profileSampleRate: Double
 			if (BuildConfig.DEBUG) {
 				sampleRate = 1.0
-				sessionSampleRate = 1.0
+				profileSampleRate = 1.0
 			} else {
 				sampleRate = 0.1
-				sessionSampleRate = 0.05
+				profileSampleRate = 0.05
 			}
 
 			options.sampleRate = sampleRate
-			options.profileSessionSampleRate = sessionSampleRate
-			options.sessionReplay.onErrorSampleRate = sampleRate
-			options.sessionReplay.sessionSampleRate = sessionSampleRate
+			options.profileSessionSampleRate = profileSampleRate
+			// Session Replay must stay disabled: its recorder thread holds
+			// ReplayIntegration's lock while encoding video, and the main thread
+			// blocks on that lock on every foreground transition
+			// (LifecycleWatcher.onForeground), causing ANR kills. Both rates must
+			// be zero — a non-zero onErrorSampleRate still runs the recorder in
+			// buffered mode. Explicit zeros also override any manifest meta-data.
+			options.sessionReplay.onErrorSampleRate = 0.0
+			options.sessionReplay.sessionSampleRate = 0.0
 
 			options.beforeSend =
 				SentryOptions.BeforeSendCallback { event: SentryEvent, _: Hint ->


### PR DESCRIPTION
The replay recorder thread holds ReplayIntegration's lock while encoding video segments; the main thread blocks on that lock on every background-to-foreground transition (LifecycleWatcher.onForeground). Any pending main-thread work then misses its deadline and the system kills the app — seen in the field as repeated ANR exits on the DISCONNECT notification broadcast and on input dispatch (frozen UI when reopening the app or the server list), plus general jank from the always-on screen encoder. Debug builds were sampling replay at 100%, release at 5%.

Both replay rates must be zero: a non-zero onErrorSampleRate still runs the recorder in buffered mode. Error and profile sampling are unchanged.

Tested successfully on  Redmi K70 Pro

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6248)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled session replay recording to prevent unnecessary background activity.
  * Sentry error and session replay sampling settings are now consistently disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->