### PR TITLE
fix(windows): handle unsupported systems and missing runtimes

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Windows] Show actionable native errors for unsupported Windows versions and missing or damaged WebView2 instead of crashing during startup
+- [Windows] Recheck and repair WebView2 and Visual C++ prerequisites during installation and updates
+
 ## [2026.12.2] - 2026-08-25
 
 ## [2026.12.1] - 2026-08-22

--- a/nym-vpn-app/README.md
+++ b/nym-vpn-app/README.md
@@ -55,6 +55,11 @@ look for release tag `nym-vpn-app-v*` and download `NymVPN.AppImage`.
 
 ### Windows
 
+NymVPN [supports Windows 10 and Windows 11](https://support.nym.com/hc/en-us/articles/22692547666193-What-devices-and-operating-systems-does-NymVPN-support)
+on x64 and ARM64 devices. The installer checks the Windows version and installs
+the required Microsoft [Edge WebView2](https://support.nym.com/hc/en-us/articles/29036510423697-Why-does-NymVPN-require-Edge-WebView2-a-Microsoft-product-upon-Windows-installation)
+and Visual C++ runtimes when they are missing.
+
 The installer is available in the
 [releases](https://github.com/nymtech/nym-vpn-client/releases).\
 Look for release tag `nym-vpn-app-v*`, download

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -7016,7 +7016,7 @@ dependencies = [
  "nym-common 2026.13.0-beta.1",
  "nym-windows",
  "rtnetlink",
- "system-configuration 0.7.0",
+ "system-configuration 0.8.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7618,6 +7618,7 @@ dependencies = [
  "url",
  "walkdir",
  "windows 0.61.3",
+ "windows-version",
  "winreg 0.52.0",
  "zip 7.2.0",
 ]
@@ -11178,6 +11179,17 @@ checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501336eb7ba9e417300a6a0fa985721065467aa83a6dcf0422a8e43e4c0328fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "system-configuration-sys 0.6.0",
 ]
 

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -85,6 +85,7 @@ tauri-plugin-autostart = "2.5.0"
 tauri-plugin-deep-link = "2"
 
 [target."cfg(windows)".dependencies]
+windows-version = "0.1.7"
 windows = { version = "0.61.3", features = [
     "Win32_System_Console",
     "Win32_Foundation",

--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -433,9 +433,10 @@ Function PageLeaveReinstall
     Goto reinst_uninstall
   ${EndIf}
 
-  ; In update mode, always proceeds without uninstalling
+  ; In update mode, defer stopping and uninstalling the service until the
+  ; Install section. WebView2 and VCRedist run before that section, so a failed
+  ; prerequisite leaves the existing service intact.
   ${If} $UpdateMode = 1
-    Call VpndUninstall
     Goto reinst_done
   ${EndIf}
 
@@ -894,6 +895,12 @@ Section Install
   !endif
 
   !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  ; Update prerequisites have now succeeded, so it is safe to replace the
+  ; existing VPN service and binaries.
+  ${If} $UpdateMode = 1
+    Call VpndUninstall
+  ${EndIf}
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"

--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -16,6 +16,7 @@ ManifestDPIAwareness PerMonitorV2
 !include MUI2.nsh
 !include FileFunc.nsh
 !include x64.nsh
+!include WinVer.nsh
 !include WordFunc.nsh
 !include "utils.nsh"
 !include "FileAssociation.nsh"
@@ -32,6 +33,11 @@ ${UnStrTok}
 {{/if}}
 
 !define WEBVIEW2APPGUID "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+!define WEBVIEW2DOWNLOADURL "https://developer.microsoft.com/microsoft-edge/webview2/#download-section"
+!define VCREDISTHELPURL "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist"
+!define WINDOWSUPGRADEURL "https://support.microsoft.com/windows/upgrade-to-windows-11-faq-fb6206a2-1a0f-448a-80f1-8668ee5b2bf9"
+!define ERROR_INSTALL_FAILURE 1603
+!define ERROR_UNSUPPORTED_PLATFORM 1633
 
 !define MANUFACTURER "{{manufacturer}}"
 !define PRODUCTNAME "{{product_name}}"
@@ -590,6 +596,20 @@ FunctionEnd
   !include "{{this}}"
 {{/each}}
 
+Function AbortUnsupportedWindows
+  DetailPrint "Unsupported Windows version. NymVPN requires Windows 10 or Windows 11."
+  ${If} $PassiveMode = 1
+    Goto unsupported_windows_exit
+  ${EndIf}
+  ${IfNot} ${Silent}
+    MessageBox MB_ICONSTOP|MB_YESNO "This version of Windows is not supported. NymVPN requires Windows 10 or Windows 11.$\r$\n$\r$\nUpgrade Windows, then run setup again.$\r$\n$\r$\nOpen Microsoft's Windows upgrade help now?" /SD IDNO IDNO unsupported_windows_exit
+    ExecShell "open" "${WINDOWSUPGRADEURL}"
+  ${EndIf}
+  unsupported_windows_exit:
+  SetErrorLevel ${ERROR_UNSUPPORTED_PLATFORM}
+  Quit
+FunctionEnd
+
 Function .onInit
   ${GetOptions} $CMDLINE "/P" $PassiveMode
   ${IfNot} ${Errors}
@@ -611,6 +631,14 @@ Function .onInit
   ${GetOptions} $CMDLINE "/FORCEVCREDIST" $ForceVCRedistMode
   ${IfNot} ${Errors}
     StrCpy $ForceVCRedistMode 1
+  ${EndIf}
+
+  ; Reject unsupported systems before selecting an install location or making
+  ; any changes to files and services.
+  ${IfNot} ${AtLeastWin10}
+    Call AbortUnsupportedWindows
+  ${ElseIf} ${IsServerOS}
+    Call AbortUnsupportedWindows
   ${EndIf}
 
   !if "${DISPLAYLANGUAGESELECTOR}" == "true"
@@ -679,54 +707,75 @@ Section WebView2
 
   ${If} $4 == ""
     ; Webview2 installation
-    ;
-    ; Skip if updating
-    ${If} $UpdateMode <> 1
-      !if "${INSTALLWEBVIEW2MODE}" == "downloadBootstrapper"
-        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-        DetailPrint "$(webview2Downloading)"
-        NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-        Pop $0
-        ${If} $0 == "success"
-          DetailPrint "$(webview2DownloadSuccess)"
-        ${Else}
-          DetailPrint "$(webview2DownloadError)"
-          Abort "$(webview2AbortError)"
+    !if "${INSTALLWEBVIEW2MODE}" == "downloadBootstrapper"
+      webview2_download:
+      Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+      DetailPrint "$(webview2Downloading)"
+      NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+      Pop $0
+      ${If} $0 == "success"
+        DetailPrint "$(webview2DownloadSuccess)"
+      ${Else}
+        DetailPrint "WebView2 bootstrapper download failed: $0"
+        ${If} $PassiveMode = 1
+        ${OrIf} ${Silent}
+          Goto webview2_manual_repair
         ${EndIf}
-        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-        Goto install_webview2
-      !endif
+        MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "NymVPN requires Microsoft Edge WebView2 Runtime, but setup could not download it.$\r$\n$\r$\nCheck your internet connection and select Retry, or select Cancel for Microsoft's manual download page." /SD IDCANCEL IDRETRY webview2_download
+        Goto webview2_manual_repair
+      ${EndIf}
+      StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+      Goto install_webview2
+    !endif
 
-      !if "${INSTALLWEBVIEW2MODE}" == "embedBootstrapper"
-        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-        File "/oname=$TEMP\MicrosoftEdgeWebview2Setup.exe" "${WEBVIEW2BOOTSTRAPPERPATH}"
-        DetailPrint "$(installingWebview2)"
-        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-        Goto install_webview2
-      !endif
+    !if "${INSTALLWEBVIEW2MODE}" == "embedBootstrapper"
+      Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+      File "/oname=$TEMP\MicrosoftEdgeWebview2Setup.exe" "${WEBVIEW2BOOTSTRAPPERPATH}"
+      DetailPrint "$(installingWebview2)"
+      StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+      Goto install_webview2
+    !endif
 
-      !if "${INSTALLWEBVIEW2MODE}" == "offlineInstaller"
-        Delete "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
-        File "/oname=$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe" "${WEBVIEW2INSTALLERPATH}"
-        DetailPrint "$(installingWebview2)"
-        StrCpy $6 "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
-        Goto install_webview2
-      !endif
+    !if "${INSTALLWEBVIEW2MODE}" == "offlineInstaller"
+      Delete "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+      File "/oname=$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe" "${WEBVIEW2INSTALLERPATH}"
+      DetailPrint "$(installingWebview2)"
+      StrCpy $6 "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+      Goto install_webview2
+    !endif
 
-      Goto webview2_done
+    Goto webview2_done
 
-      install_webview2:
-        DetailPrint "$(installingWebview2)"
-        ; $6 holds the path to the webview2 installer
-        ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
-        ${If} $1 = 0
-          DetailPrint "$(webview2InstallSuccess)"
-        ${Else}
-          DetailPrint "$(webview2InstallError)"
-          Abort "$(webview2AbortError)"
+    install_webview2:
+      DetailPrint "$(installingWebview2)"
+      ; $6 holds the path to the webview2 installer
+      ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
+      ${If} $1 = 0
+        DetailPrint "$(webview2InstallSuccess)"
+        Goto webview2_done
+      ${Else}
+        DetailPrint "WebView2 Runtime installation failed: $1"
+        ${If} $PassiveMode = 1
+        ${OrIf} ${Silent}
+          Goto webview2_manual_repair
         ${EndIf}
-      webview2_done:
-    ${EndIf}
+        MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "NymVPN requires Microsoft Edge WebView2 Runtime, but the component could not be installed.$\r$\n$\r$\nSelect Retry to try again, or select Cancel for Microsoft's manual download page." /SD IDCANCEL IDRETRY install_webview2
+      ${EndIf}
+
+    webview2_manual_repair:
+      DetailPrint "WebView2 is required; setup cannot continue"
+      ${If} $PassiveMode = 1
+        Goto webview2_abort
+      ${EndIf}
+      ${IfNot} ${Silent}
+        MessageBox MB_ICONINFORMATION|MB_YESNO "Install or repair Microsoft Edge WebView2 Runtime, then run NymVPN setup again.$\r$\n$\r$\nOpen Microsoft's WebView2 download page now?" /SD IDNO IDNO webview2_abort
+        ExecShell "open" "${WEBVIEW2DOWNLOADURL}"
+      ${EndIf}
+    webview2_abort:
+      SetErrorLevel ${ERROR_INSTALL_FAILURE}
+      Abort
+
+    webview2_done:
   ${Else}
     !if "${MINIMUMWEBVIEW2VERSION}" != ""
       ${VersionCompare} "${MINIMUMWEBVIEW2VERSION}" "$4" $R0
@@ -748,10 +797,17 @@ Section WebView2
             ${If} $1 = 0
               DetailPrint "$(webview2InstallSuccess)"
             ${Else}
-              MessageBox MB_ICONEXCLAMATION|MB_ABORTRETRYIGNORE "$(webview2InstallError)" IDIGNORE ignore IDRETRY update_webview
-              Quit
-              ignore:
+              DetailPrint "WebView2 Runtime update failed: $1"
+              ${If} $PassiveMode = 1
+              ${OrIf} ${Silent}
+                Goto webview2_manual_repair
+              ${EndIf}
+              MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "NymVPN requires a newer Microsoft Edge WebView2 Runtime, but setup could not update it.$\r$\n$\r$\nSelect Retry to try again, or select Cancel for Microsoft's manual download page." /SD IDCANCEL IDRETRY update_webview
+              Goto webview2_manual_repair
             ${EndIf}
+          ${Else}
+            DetailPrint "Microsoft Edge Update could not be found"
+            Goto webview2_manual_repair
           ${EndIf}
       ${EndIf}
     !endif
@@ -771,29 +827,62 @@ Section VCRedist
     ; $PLUGINSDIR is a private, installer-only temp directory (created on the
     ; first plugin call below, deleted automatically when the installer exits),
     ; unlike the predictable, shared $TEMP path.
+    vcredist_download:
+    Delete "$PLUGINSDIR\vc_redist.exe"
     DetailPrint "Downloading Visual C++ Redistributable (${VCREDISTARCH})"
     NSISdl::download "${VCREDISTURL}" "$PLUGINSDIR\vc_redist.exe"
     Pop $5
     ${If} $5 != "success"
       DetailPrint "vc_redist.exe download failed: $5"
-      Abort "Failed to download the Visual C++ Redistributable [$5]"
+      ${If} $PassiveMode = 1
+      ${OrIf} ${Silent}
+        Goto vcredist_manual_repair
+      ${EndIf}
+      MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "NymVPN requires the Microsoft Visual C++ Runtime, but setup could not download it.$\r$\n$\r$\nCheck your internet connection and select Retry, or select Cancel for Microsoft's manual download page." /SD IDCANCEL IDRETRY vcredist_download
+      Goto vcredist_manual_repair
     ${EndIf}
     DetailPrint "Visual C++ Redistributable downloaded successfully"
 
+    vcredist_install:
     DetailPrint "Installing Visual C++ Redistributable (${VCREDISTARCH})"
     ExecWait '"$PLUGINSDIR\vc_redist.exe" /install /quiet /norestart' $5
-    Delete "$PLUGINSDIR\vc_redist.exe"
     ${If} $5 = 0
       DetailPrint "Visual C++ Redistributable installed successfully"
+      Delete "$PLUGINSDIR\vc_redist.exe"
     ${ElseIf} $5 = 3010 ; ERROR_SUCCESS_REBOOT_REQUIRED
       DetailPrint "Visual C++ Redistributable installed successfully, a reboot is required"
+      Delete "$PLUGINSDIR\vc_redist.exe"
       SetRebootFlag true
     ${ElseIf} $5 = 1638 ; ERROR_PRODUCT_VERSION: a matching/newer version is already installed
       DetailPrint "Visual C++ Redistributable is already installed"
+      Delete "$PLUGINSDIR\vc_redist.exe"
     ${Else}
       DetailPrint "vc_redist.exe install failed: $5"
-      Abort "Failed to install the Visual C++ Redistributable [$5]"
+      ${If} $PassiveMode = 1
+      ${OrIf} ${Silent}
+        Delete "$PLUGINSDIR\vc_redist.exe"
+        Goto vcredist_manual_repair
+      ${EndIf}
+      MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "NymVPN requires the Microsoft Visual C++ Runtime, but the component could not be installed.$\r$\n$\r$\nSelect Retry to try again, or select Cancel for Microsoft's manual download page." /SD IDCANCEL IDRETRY vcredist_install
+      Delete "$PLUGINSDIR\vc_redist.exe"
+      Goto vcredist_manual_repair
     ${EndIf}
+    Goto vcredist_done
+
+    vcredist_manual_repair:
+      DetailPrint "Microsoft Visual C++ Runtime is required; setup cannot continue"
+      ${If} $PassiveMode = 1
+        Goto vcredist_abort
+      ${EndIf}
+      ${IfNot} ${Silent}
+        MessageBox MB_ICONINFORMATION|MB_YESNO "Install or repair the Microsoft Visual C++ Runtime for ${VCREDISTARCH}, then run NymVPN setup again.$\r$\n$\r$\nOpen Microsoft's download page now?" /SD IDNO IDNO vcredist_abort
+        ExecShell "open" "${VCREDISTHELPURL}"
+      ${EndIf}
+    vcredist_abort:
+      SetErrorLevel ${ERROR_INSTALL_FAILURE}
+      Abort
+
+    vcredist_done:
   ${EndIf}
 SectionEnd
 

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::time::Duration;
+use std::{process::ExitCode, time::Duration};
 
 use crate::cli::{Commands, db_command};
 use crate::favorites::FavoritesState;
@@ -68,6 +68,8 @@ mod updater;
 mod vpnd;
 mod vpnd_check;
 mod window;
+#[cfg(windows)]
+mod windows_startup;
 
 pub const APP_NAME: &str = "NymVPN";
 pub const APP_DIR: &str = "nym-vpn-app";
@@ -85,7 +87,21 @@ const DEFAULT_DEBUG_LOGGING: bool = true;
 build_info::build_info!(fn build_info);
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> ExitCode {
+    match run_application().await {
+        Ok(exit_code) => exit_code,
+        Err(error) => {
+            error!(%error, "fatal application startup error");
+            #[cfg(windows)]
+            windows_startup::show_native_error(windows_startup::NativeStartupError::Unexpected);
+            #[cfg(not(windows))]
+            eprintln!("NymVPN failed to start: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run_application() -> Result<ExitCode> {
     dotenvy::dotenv().ok();
 
     #[cfg(all(not(debug_assertions), windows))]
@@ -95,7 +111,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     if cli.clean_local_files {
         fs::util::clean_local_files();
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
     let app_config = AppConfig::read().ok();
     let sentry_enabled = app_config
@@ -128,11 +144,19 @@ async fn main() -> Result<()> {
 
     if cli.build_info {
         cli::print_build_info(pkg_info);
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
     if let Some(Commands::Db { command: Some(cmd) }) = &cli.command {
-        return db_command(cmd);
+        db_command(cmd)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    #[cfg(windows)]
+    if let Err(error) = windows_startup::check_prerequisites() {
+        error!(%error, "Windows prerequisite check failed");
+        windows_startup::show_native_error(error.native_error());
+        return Ok(ExitCode::FAILURE);
     }
 
     let sentry_guard = if sentry_enabled {
@@ -236,7 +260,16 @@ async fn main() -> Result<()> {
                 .ok();
             app.manage(db.clone());
 
-            let app_window = AppWindow::create_main_window(app.handle(), &cli)?;
+            let app_window =
+                AppWindow::create_main_window(app.handle(), &cli).inspect_err(|_error| {
+                    #[cfg(windows)]
+                    {
+                        error!(%_error, "failed to initialize the Windows webview");
+                        windows_startup::show_native_error(
+                            windows_startup::NativeStartupError::WebView2Unavailable,
+                        );
+                    }
+                })?;
             app_window.set_bg_color(&db).ok();
             #[cfg(target_os = "linux")]
             app_window.set_max_size(os.display_server.clone()).ok();
@@ -417,8 +450,7 @@ async fn main() -> Result<()> {
             #[cfg(windows)]
             cmd_updater::install_update,
         ])
-        .run(context)
-        .expect("error while running tauri application");
+        .run(context)?;
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }

--- a/nym-vpn-app/src-tauri/src/windows_startup.rs
+++ b/nym-vpn-app/src-tauri/src/windows_startup.rs
@@ -1,0 +1,328 @@
+use std::{
+    fmt, iter,
+    os::windows::ffi::OsStrExt,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use windows::{
+    Win32::UI::{
+        Shell::ShellExecuteW,
+        WindowsAndMessaging::{
+            IDYES, MB_ICONERROR, MB_SETFOREGROUND, MB_YESNO, MessageBoxW, SW_SHOWNORMAL,
+        },
+    },
+    core::{PCWSTR, w},
+};
+use windows_version::{OsVersion, is_server};
+
+const WINDOWS_UPGRADE_URL: &str = "https://support.microsoft.com/windows/upgrade-to-windows-11-faq-fb6206a2-1a0f-448a-80f1-8668ee5b2bf9";
+const WEBVIEW2_DOWNLOAD_URL: &str =
+    "https://developer.microsoft.com/microsoft-edge/webview2/#download-section";
+const NYM_SUPPORT_URL: &str = "https://support.nym.com/";
+const MINIMUM_WINDOWS_MAJOR_VERSION: u32 = 10;
+
+static NATIVE_ERROR_SHOWN: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WindowsVersion {
+    major: u32,
+    minor: u32,
+    build: u32,
+    server: bool,
+}
+
+impl fmt::Display for WindowsVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.build)?;
+        if self.server {
+            write!(f, " (server)")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WindowsCompatibility {
+    Supported,
+    Unsupported,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum WebView2Compatibility {
+    Available(String),
+    MissingOrDamaged(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeStartupError {
+    UnsupportedWindows,
+    WebView2Unavailable,
+    Unexpected,
+}
+
+impl NativeStartupError {
+    fn dialog(self) -> NativeDialog {
+        match self {
+            Self::UnsupportedWindows => NativeDialog {
+                title: "NymVPN requires a newer version of Windows",
+                message: "This version of Windows is not supported. NymVPN requires Windows 10 or Windows 11. Upgrade Windows, then try again.\n\nOpen Microsoft's Windows upgrade help now?",
+                action_url: WINDOWS_UPGRADE_URL,
+            },
+            Self::WebView2Unavailable => NativeDialog {
+                title: "NymVPN needs Microsoft Edge WebView2",
+                message: "NymVPN could not start because Microsoft Edge WebView2 Runtime is missing, damaged, or could not be initialized. WebView2 displays the NymVPN interface. Install or repair it, then reopen NymVPN.\n\nOpen Microsoft's WebView2 download page now?",
+                action_url: WEBVIEW2_DOWNLOAD_URL,
+            },
+            Self::Unexpected => NativeDialog {
+                title: "NymVPN could not start",
+                message: "NymVPN encountered a problem while starting. Restart the app and try again. If the problem continues, reinstall NymVPN or contact Nym Support.\n\nOpen Nym Support now?",
+                action_url: NYM_SUPPORT_URL,
+            },
+        }
+    }
+}
+
+struct NativeDialog {
+    title: &'static str,
+    message: &'static str,
+    action_url: &'static str,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PrerequisiteError {
+    #[error("unsupported Windows version: {0}")]
+    UnsupportedWindows(WindowsVersion),
+    #[error("Microsoft Edge WebView2 Runtime is unavailable: {0}")]
+    WebView2Unavailable(String),
+}
+
+impl PrerequisiteError {
+    pub(crate) fn native_error(&self) -> NativeStartupError {
+        match self {
+            Self::UnsupportedWindows(_) => NativeStartupError::UnsupportedWindows,
+            Self::WebView2Unavailable(_) => NativeStartupError::WebView2Unavailable,
+        }
+    }
+}
+
+pub(crate) fn check_prerequisites() -> Result<(), PrerequisiteError> {
+    let version = detect_windows_version();
+    match classify_windows_version(version) {
+        WindowsCompatibility::Supported => {
+            if let Some(version) = version {
+                tracing::info!(%version, "supported Windows version detected");
+            }
+        }
+        WindowsCompatibility::Unsupported => {
+            if let Some(version) = version {
+                return Err(PrerequisiteError::UnsupportedWindows(version));
+            }
+            tracing::warn!("Windows compatibility was unknown; continuing startup");
+        }
+        WindowsCompatibility::Unknown => {
+            tracing::warn!("failed to determine the Windows version; continuing startup");
+        }
+    }
+
+    match classify_webview_probe(tauri::webview_version().map_err(|error| error.to_string())) {
+        WebView2Compatibility::Available(version) => {
+            tracing::info!(%version, "Microsoft Edge WebView2 Runtime detected");
+            Ok(())
+        }
+        WebView2Compatibility::MissingOrDamaged(reason) => {
+            Err(PrerequisiteError::WebView2Unavailable(reason))
+        }
+    }
+}
+
+pub(crate) fn show_native_error(error: NativeStartupError) {
+    if NATIVE_ERROR_SHOWN.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let dialog = error.dialog();
+    let title = wide_string(dialog.title);
+    let message = wide_string(dialog.message);
+
+    let result = unsafe {
+        MessageBoxW(
+            None,
+            PCWSTR(message.as_ptr()),
+            PCWSTR(title.as_ptr()),
+            MB_ICONERROR | MB_YESNO | MB_SETFOREGROUND,
+        )
+    };
+
+    if result == IDYES {
+        open_url(dialog.action_url);
+    }
+}
+
+fn open_url(url: &str) {
+    let url = wide_string(url);
+    let result = unsafe {
+        ShellExecuteW(
+            None,
+            w!("open"),
+            PCWSTR(url.as_ptr()),
+            None,
+            None,
+            SW_SHOWNORMAL,
+        )
+    };
+    if result.0 as isize <= 32 {
+        tracing::warn!(code = result.0 as isize, "failed to open startup help URL");
+    }
+}
+
+fn detect_windows_version() -> Option<WindowsVersion> {
+    let version = OsVersion::current();
+    if version.major == 0 {
+        return None;
+    }
+
+    Some(WindowsVersion {
+        major: version.major,
+        minor: version.minor,
+        build: version.build,
+        server: is_server(),
+    })
+}
+
+fn classify_windows_version(version: Option<WindowsVersion>) -> WindowsCompatibility {
+    match version {
+        None => WindowsCompatibility::Unknown,
+        Some(version) if version.server || version.major < MINIMUM_WINDOWS_MAJOR_VERSION => {
+            WindowsCompatibility::Unsupported
+        }
+        Some(_) => WindowsCompatibility::Supported,
+    }
+}
+
+fn classify_webview_probe(probe: Result<String, String>) -> WebView2Compatibility {
+    match probe {
+        Ok(version) if !version.trim().is_empty() && version.trim() != "0.0.0.0" => {
+            WebView2Compatibility::Available(version)
+        }
+        Ok(version) => WebView2Compatibility::MissingOrDamaged(format!(
+            "the reported runtime version is invalid: {version:?}"
+        )),
+        Err(error) => WebView2Compatibility::MissingOrDamaged(error),
+    }
+}
+
+fn wide_string(value: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client_version(major: u32, minor: u32, build: u32) -> WindowsVersion {
+        WindowsVersion {
+            major,
+            minor,
+            build,
+            server: false,
+        }
+    }
+
+    #[test]
+    fn rejects_legacy_windows_clients() {
+        for version in [
+            client_version(6, 1, 7601),
+            client_version(6, 2, 9200),
+            client_version(6, 3, 9600),
+        ] {
+            assert_eq!(
+                classify_windows_version(Some(version)),
+                WindowsCompatibility::Unsupported
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_windows_10_11_and_future_client_versions() {
+        for version in [
+            client_version(10, 0, 10240),
+            client_version(10, 0, 19045),
+            client_version(10, 0, 26100),
+            client_version(11, 0, 1),
+        ] {
+            assert_eq!(
+                classify_windows_version(Some(version)),
+                WindowsCompatibility::Supported
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_windows_server() {
+        let version = WindowsVersion {
+            server: true,
+            ..client_version(10, 0, 26100)
+        };
+        assert_eq!(
+            classify_windows_version(Some(version)),
+            WindowsCompatibility::Unsupported
+        );
+    }
+
+    #[test]
+    fn unknown_windows_version_fails_open() {
+        assert_eq!(
+            classify_windows_version(None),
+            WindowsCompatibility::Unknown
+        );
+    }
+
+    #[test]
+    fn classifies_webview2_probe_results() {
+        assert!(matches!(
+            classify_webview_probe(Ok("151.0.4129.50".to_owned())),
+            WebView2Compatibility::Available(_)
+        ));
+        assert!(matches!(
+            classify_webview_probe(Ok(String::new())),
+            WebView2Compatibility::MissingOrDamaged(_)
+        ));
+        assert!(matches!(
+            classify_webview_probe(Ok("0.0.0.0".to_owned())),
+            WebView2Compatibility::MissingOrDamaged(_)
+        ));
+        assert!(matches!(
+            classify_webview_probe(Err("probe failed".to_owned())),
+            WebView2Compatibility::MissingOrDamaged(_)
+        ));
+    }
+
+    #[test]
+    fn maps_prerequisite_failures_to_actionable_dialogs() {
+        assert_eq!(
+            PrerequisiteError::UnsupportedWindows(client_version(6, 3, 9600)).native_error(),
+            NativeStartupError::UnsupportedWindows
+        );
+        assert_eq!(
+            PrerequisiteError::WebView2Unavailable("probe failed".to_owned()).native_error(),
+            NativeStartupError::WebView2Unavailable
+        );
+
+        assert_eq!(
+            NativeStartupError::UnsupportedWindows.dialog().action_url,
+            WINDOWS_UPGRADE_URL
+        );
+        assert_eq!(
+            NativeStartupError::WebView2Unavailable.dialog().action_url,
+            WEBVIEW2_DOWNLOAD_URL
+        );
+        assert_eq!(
+            NativeStartupError::Unexpected.dialog().action_url,
+            NYM_SUPPORT_URL
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

N/A

## Description

Improve Windows startup and installer failure handling so unsupported systems and missing prerequisites fail clearly and without application panics.

- Reject Windows client versions older than Windows 10 and Windows Server before installation or desktop initialization, while failing open if native version detection is unavailable.
- Probe Edge WebView2 before creating a webview and use Win32-native dialogs for unsupported Windows, missing or damaged WebView2, and unexpected startup failures.
- Propagate Tauri startup errors to a controlled nonzero exit instead of panicking, while preserving the existing database error webview when it can be created.
- Recheck WebView2 during updates, add download/install retries and official manual-repair links for WebView2 and Visual C++, and stop before service installation whenever a prerequisite fails.
- Document supported Windows versions and automatic prerequisite handling.

Policy and implementation references:

- [NymVPN supported devices and operating systems](https://support.nym.com/hc/en-us/articles/22692547666193-What-devices-and-operating-systems-does-NymVPN-support)
- [Why NymVPN requires Edge WebView2](https://support.nym.com/hc/en-us/articles/29036510423697-Why-does-NymVPN-require-Edge-WebView2-a-Microsoft-product-upon-Windows-installation)
- [Tauri Windows installer WebView2 options](https://v2.tauri.app/distribute/windows-installer/)

## Test evidence

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked` (104 passed)
- Windows-only startup module compile/Clippy checks for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` with warnings denied
- NSIS 3.12 warning-denied compile smoke tests of the changed installer blocks for x64 and ARM64, including their architecture-specific Visual C++ packages
- `npm run tscheck`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`

A complete Windows app/installer build and the Windows VM acceptance matrix remain for the Windows CI/QA environment. A macOS-to-Windows full Cargo cross-check reaches an upstream C dependency but cannot proceed without the Microsoft C headers.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

Native Windows dialog screenshots require a Windows desktop session and could not be captured on the macOS development host. The dialogs and their action links are covered by unit tests; screenshots can be added from Windows QA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6249)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NymVPN now shows actionable Windows error messages instead of crashing when the operating system is unsupported or WebView2 is unavailable.
  * The installer rechecks and repairs required WebView2 and Visual C++ components during installation and updates.
  * Installation failures now offer retry, cancellation, and links to Microsoft repair guidance.
  * Unsupported Windows versions and server editions are blocked with a clear message.
  * Failed prerequisite updates no longer remove the existing VPN service.

* **Documentation**
  * Documented Windows 10/11 support for x64 and ARM64 devices and prerequisite installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->