### PR TITLE
feat: add special upstream unavailable retry for mid-ceremony halts

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -13,6 +13,11 @@ pub const UNREGISTER_NON_EXISTENT_DEVICE_CODE_ID: &str = "235ba475-8c64-4c46-814
 // https://github.com/nymtech/websites/blob/e92383143e195c97c2a3043d93daff06debaab74/www/vpn-api/src/app/api/public/v1/account/%5BaccountId%5D/device/%5BdeviceId%5D/zknym/route.ts#L255
 pub const FAIR_USAGE_DEPLETED_CODE_ID: &str = "e0b78604-bb9b-4524-add1-f50fe26144c6";
 
+// The credential proxy refused issuance on a condition that clears by itself within minutes, most
+// notably while the network rotates its signing keys. Retrying the same request later succeeds.
+// https://github.com/nymtech/websites/blob/27bb28f1f765703e3f26e0c04995f8386246f9a4/www/vpn-api/src/app/api/public/v1/account/%5BaccountId%5D/device/%5BdeviceId%5D/zknym/route.ts#L284
+pub const UPSTREAM_UNAVAILABLE_CODE_ID: &str = "b4f0a4a9-7c31-4e7c-9b0e-52c1f8e2d6a7";
+
 #[derive(Debug, thiserror::Error)]
 pub enum VpnApiClientError {
     #[error("failed to create vpn api client")]

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/error.rs
@@ -3,7 +3,9 @@
 
 use nym_bandwidth_controller::{FetcherError, error::FetcherErrorKind};
 use nym_credentials_interface::CompactEcashError;
-use nym_vpn_api_client::error::{FAIR_USAGE_DEPLETED_CODE_ID, VpnApiClientError};
+use nym_vpn_api_client::error::{
+    FAIR_USAGE_DEPLETED_CODE_ID, UPSTREAM_UNAVAILABLE_CODE_ID, VpnApiClientError,
+};
 use nym_vpn_lib_types::{VpnApiError, VpnApiErrorResponse};
 
 use crate::{credential_request::ZkNymId, storage::error::PendingCredentialRequestsStorageError};
@@ -76,6 +78,9 @@ pub enum VpnApiFetcherError {
     #[error("no fair usage left")]
     BandwidthExceeded,
 
+    #[error("issuance is briefly unavailable upstream")]
+    UpstreamUnavailable,
+
     // Cryptographic errors
     #[error("failed to create ecash keypair: {0}")]
     CreateEcashKeyPair(String),
@@ -98,7 +103,9 @@ pub enum VpnApiFetcherError {
 
 impl VpnApiFetcherError {
     /// Whether this error is worth retrying: a transient network/availability failure rather than a
-    /// definitive protocol, cryptographic, or server-side rejection.
+    /// definitive protocol, cryptographic, or server-side rejection. Not the full retry picture:
+    /// [`UpstreamUnavailable`](Self::UpstreamUnavailable) is also retried, on its own fixed
+    /// schedule in [`with_retries`](crate::utils::with_retries), deliberately outside this set.
     pub(crate) fn is_retryable(&self) -> bool {
         matches!(
             self,
@@ -112,6 +119,8 @@ impl VpnApiFetcherError {
             Ok(VpnApiError::Response(source)) => {
                 if source.code_reference_id.as_deref() == Some(FAIR_USAGE_DEPLETED_CODE_ID) {
                     Self::BandwidthExceeded
+                } else if source.code_reference_id.as_deref() == Some(UPSTREAM_UNAVAILABLE_CODE_ID) {
+                    Self::UpstreamUnavailable
                 } else {
                     Self::ApiErrorResponse {
                         endpoint: endpoint.into(),
@@ -143,6 +152,7 @@ impl FetcherError for VpnApiFetcherError {
             | VpnApiFetcherError::ApiStatusCodeError { .. }
             | VpnApiFetcherError::ApiErrorResponse { .. }
             | VpnApiFetcherError::Transport { .. }
+            | VpnApiFetcherError::UpstreamUnavailable
             | VpnApiFetcherError::IssuanceError => FetcherErrorKind::Api,
 
             VpnApiFetcherError::InconsistentResponse(_) => FetcherErrorKind::Unexpected,

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/error.rs
@@ -119,7 +119,8 @@ impl VpnApiFetcherError {
             Ok(VpnApiError::Response(source)) => {
                 if source.code_reference_id.as_deref() == Some(FAIR_USAGE_DEPLETED_CODE_ID) {
                     Self::BandwidthExceeded
-                } else if source.code_reference_id.as_deref() == Some(UPSTREAM_UNAVAILABLE_CODE_ID) {
+                } else if source.code_reference_id.as_deref() == Some(UPSTREAM_UNAVAILABLE_CODE_ID)
+                {
                     Self::UpstreamUnavailable
                 } else {
                     Self::ApiErrorResponse {

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/fetcher.rs
@@ -208,9 +208,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
         epoch_id: EpochId,
     ) -> Result<EpochVerificationKey, CredentialFetcherError> {
         Ok(self
-            .run_while_active(|| {
-                with_retries(|| self.do_fetch_master_verification_key(epoch_id))
-            })
+            .run_while_active(|| with_retries(|| self.do_fetch_master_verification_key(epoch_id)))
             .await??)
     }
 
@@ -219,9 +217,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
         epoch_id: EpochId,
     ) -> Result<AggregatedCoinIndicesSignatures, CredentialFetcherError> {
         Ok(self
-            .run_while_active(|| {
-                with_retries(|| self.do_fetch_coin_index_signatures(epoch_id))
-            })
+            .run_while_active(|| with_retries(|| self.do_fetch_coin_index_signatures(epoch_id)))
             .await??)
     }
 
@@ -232,9 +228,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
     ) -> Result<AggregatedExpirationDateSignatures, CredentialFetcherError> {
         Ok(self
             .run_while_active(|| {
-                with_retries(|| {
-                    self.do_fetch_expiration_date_signatures(expiration_date, epoch_id)
-                })
+                with_retries(|| self.do_fetch_expiration_date_signatures(expiration_date, epoch_id))
             })
             .await??)
     }
@@ -256,9 +250,7 @@ impl CredentialFetcher for VpnApiCredentialFetcher {
             })
             .ok();
         Ok(self
-            .run_while_active(|| {
-                with_retries(|| self.do_fetch_ticketbooks(ticketbook_type))
-            })
+            .run_while_active(|| with_retries(|| self.do_fetch_ticketbooks(ticketbook_type)))
             .await??)
     }
 

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/fetcher.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     cached_data::CachedData, credential_request::CredentialRequestTask, error::VpnApiFetcherError,
-    storage::PendingCredentialRequestsStorage, utils::with_exponential_backoff,
+    storage::PendingCredentialRequestsStorage, utils::with_retries,
 };
 
 // Little enum to avoid a boolean in the pause/resume logic
@@ -209,7 +209,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
     ) -> Result<EpochVerificationKey, CredentialFetcherError> {
         Ok(self
             .run_while_active(|| {
-                with_exponential_backoff(|| self.do_fetch_master_verification_key(epoch_id))
+                with_retries(|| self.do_fetch_master_verification_key(epoch_id))
             })
             .await??)
     }
@@ -220,7 +220,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
     ) -> Result<AggregatedCoinIndicesSignatures, CredentialFetcherError> {
         Ok(self
             .run_while_active(|| {
-                with_exponential_backoff(|| self.do_fetch_coin_index_signatures(epoch_id))
+                with_retries(|| self.do_fetch_coin_index_signatures(epoch_id))
             })
             .await??)
     }
@@ -232,7 +232,7 @@ impl CredentialPublicDataFetcher for VpnApiCredentialFetcher {
     ) -> Result<AggregatedExpirationDateSignatures, CredentialFetcherError> {
         Ok(self
             .run_while_active(|| {
-                with_exponential_backoff(|| {
+                with_retries(|| {
                     self.do_fetch_expiration_date_signatures(expiration_date, epoch_id)
                 })
             })
@@ -257,7 +257,7 @@ impl CredentialFetcher for VpnApiCredentialFetcher {
             .ok();
         Ok(self
             .run_while_active(|| {
-                with_exponential_backoff(|| self.do_fetch_ticketbooks(ticketbook_type))
+                with_retries(|| self.do_fetch_ticketbooks(ticketbook_type))
             })
             .await??)
     }

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/utils.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/utils.rs
@@ -31,9 +31,7 @@ const UPSTREAM_UNAVAILABLE_RETRY_DELAY: Duration = Duration::from_secs(300);
 /// This helper does not itself watch for pause/cancellation; wrap it in
 /// [`run_while_active`](crate::fetcher::VpnApiCredentialFetcher::run_while_active) so a pause cancels
 /// the in-flight attempt and any backoff wait, restarting `op` from scratch on resume.
-pub(crate) async fn with_retries<Fut, T>(
-    op: impl Fn() -> Fut,
-) -> Result<T, VpnApiFetcherError>
+pub(crate) async fn with_retries<Fut, T>(op: impl Fn() -> Fut) -> Result<T, VpnApiFetcherError>
 where
     Fut: Future<Output = Result<T, VpnApiFetcherError>>,
 {

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/utils.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/utils.rs
@@ -14,15 +14,24 @@ use crate::error::VpnApiFetcherError;
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(5);
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
 
+/// Issuance being briefly unavailable upstream is paced on its own, far slower schedule, mirroring
+/// the `Retry-After: 300` the api sends with it. Every attempt spends a token from the api's
+/// per-device bucket (burst 9, refilling one per 15 minutes) before the credential proxy is even
+/// consulted, so the schedule above would empty the bucket within the first few minutes of a
+/// condition that takes tens of minutes to clear, and the retries would then fail on rate limiting
+/// rather than on the original condition.
+const UPSTREAM_UNAVAILABLE_RETRY_DELAY: Duration = Duration::from_secs(300);
+
 /// Run `op` — a fresh fetch attempt each call — retrying indefinitely on
 /// [retryable](VpnApiFetcherError::is_retryable) errors with capped exponential backoff (from
 /// [`INITIAL_RETRY_DELAY`], doubling up to [`MAX_RETRY_DELAY`]). A terminal error or a success
-/// returns immediately.
+/// returns immediately. Issuance that is briefly unavailable upstream is also retried, but on the
+/// slower fixed schedule of [`UPSTREAM_UNAVAILABLE_RETRY_DELAY`].
 ///
 /// This helper does not itself watch for pause/cancellation; wrap it in
 /// [`run_while_active`](crate::fetcher::VpnApiCredentialFetcher::run_while_active) so a pause cancels
 /// the in-flight attempt and any backoff wait, restarting `op` from scratch on resume.
-pub(crate) async fn with_exponential_backoff<Fut, T>(
+pub(crate) async fn with_retries<Fut, T>(
     op: impl Fn() -> Fut,
 ) -> Result<T, VpnApiFetcherError>
 where
@@ -32,6 +41,16 @@ where
     loop {
         match op().await {
             Ok(value) => return Ok(value),
+            // A dedicated arm rather than a member of `is_retryable()`: the pacing is the point,
+            // and a bool cannot carry it. Folding this into the backoff arm would put it on the
+            // 5s-doubling schedule, which drains the api's per-device rate bucket mid-ceremony.
+            Err(err @ VpnApiFetcherError::UpstreamUnavailable) => {
+                tracing::info!(
+                    "Issuance is briefly unavailable, retrying in {}s: {err}",
+                    UPSTREAM_UNAVAILABLE_RETRY_DELAY.as_secs()
+                );
+                tokio::time::sleep(UPSTREAM_UNAVAILABLE_RETRY_DELAY).await;
+            }
             Err(err) if err.is_retryable() => {
                 tracing::warn!("Transient fetch error, retrying in {delay:?}: {err}");
                 tokio::time::sleep(delay).await;
@@ -42,5 +61,53 @@ where
                 return Err(err);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::time::Instant;
+
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn issuance_briefly_unavailable_upstream_is_retried_on_the_slow_schedule() {
+        let attempts = AtomicUsize::new(0);
+        let started = Instant::now();
+
+        let result = with_retries(|| async {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                Err(VpnApiFetcherError::UpstreamUnavailable)
+            } else {
+                Ok(())
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        // stated independently of the constant: this mirrors the server's `Retry-After: 300`, and
+        // the pace is what keeps the per-device rate bucket alive for the whole of a ceremony
+        assert_eq!(started.elapsed(), Duration::from_secs(300));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_503_without_the_marker_still_fails_fast() {
+        let attempts = AtomicUsize::new(0);
+
+        let result: Result<(), _> = with_retries(|| async {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(VpnApiFetcherError::ApiStatusCodeError {
+                endpoint: "request_zk_nym".to_string(),
+                msg: "service unavailable".to_string(),
+                status_code: 503,
+            })
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Ticket

https://nymtech.atlassian.net/browse/NYM-1760

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6258)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN credential retrieval when the upstream service is temporarily unavailable.
  * Automatically retries transient upstream outages on a fixed schedule, reducing unnecessary request failures and rate-limit consumption.
  * Preserved faster failure behavior for other service errors, such as unmarked 503 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->