### PR TITLE
Feat/pin epoch

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -7016,7 +7016,7 @@ dependencies = [
  "nym-common 2026.13.0-beta.1",
  "nym-windows",
  "rtnetlink",
- "system-configuration 0.7.0",
+ "system-configuration 0.8.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11178,6 +11178,17 @@ checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501336eb7ba9e417300a6a0fa985721065467aa83a6dcf0422a8e43e4c0328fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "system-configuration-sys 0.6.0",
 ]
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -1024,6 +1024,7 @@ impl VpnApiClient {
             ecash_pubkey,
             expiration_date,
             ticketbook_type,
+            epoch_aware: true,
         };
         tracing::debug!("Request body: {body:#?}");
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -1435,6 +1435,7 @@ impl VpnApiClient {
 
     pub async fn get_directory_zk_nyms_ticketbook_partial_verification_keys(
         &self,
+        epoch_id: u64,
     ) -> Result<PartialVerificationKeysResponse> {
         self.get_json_with_retry(
             &[
@@ -1445,7 +1446,7 @@ impl VpnApiClient {
                 routes::TICKETBOOK,
                 routes::PARTIAL_VERIFICATION_KEYS,
             ],
-            NO_PARAMS,
+            &[(routes::EPOCH_ID, epoch_id.to_string())],
         )
         .await
         .map_err(Box::new)

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
@@ -42,6 +42,9 @@ pub struct RequestZkNymRequestBody {
     pub ecash_pubkey: String,
     pub expiration_date: String,
     pub ticketbook_type: String,
+    /// Make sure credential proxy knows we can differentiate between epochs
+    /// (allows us to request during DKG ceremony)
+    pub epoch_aware: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/cached_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/cached_data.rs
@@ -47,12 +47,14 @@ impl CachedData {
             tracing::info!("Fetching partial verification keys for epoch: {epoch_id}");
             let issuers = self
                 .vpn_api_client
-                .get_directory_zk_nyms_ticketbook_partial_verification_keys()
+                .get_directory_zk_nyms_ticketbook_partial_verification_keys(epoch_id)
                 .await
                 .map_err(VpnApiFetcherError::vpn_api_error(
                     "get_directory_zk_nyms_ticketbook_partial_verification_keys",
                 ))?;
 
+            // a vpn-api deployed without the `epoch-id` param ignores it and answers with the
+            // current epoch, which is indistinguishable from never having asked
             if issuers.epoch_id != epoch_id {
                 return Err(VpnApiFetcherError::EpochIdMismatch);
             }

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/credential_request.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/credential_request.rs
@@ -140,6 +140,42 @@ impl CredentialRequestTask {
         pending_request: PendingCredentialRequest,
     ) -> Result<NymCredential, VpnApiFetcherError> {
         let pending_request_id = pending_request.id.clone();
+
+        match self.download_zk_nym(pending_request).await {
+            Ok(success) => {
+                // Remove the pending request from the storage. We no longer need it.
+                tracing::debug!("Removing pending zk-nym request");
+                self.pending_storage
+                    .remove_pending_request(&pending_request_id)
+                    .await?;
+
+                Ok(success)
+            }
+            // The shares name the epoch they were issued under and the chain never goes back, so
+            // no number of resumes can complete this one. Keeping it would block every later
+            // acquisition of this ticket type: the api still offers it for download, and a
+            // resumable request is always preferred over a fresh one.
+            Err(err @ VpnApiFetcherError::EpochIdMismatch) => {
+                warn!("Discarding a pending zk-nym request that can never complete: {err}");
+                if let Err(remove_err) = self
+                    .pending_storage
+                    .remove_pending_request(&pending_request_id)
+                    .await
+                {
+                    warn!("Failed to remove pending zk-nym request: {remove_err}");
+                }
+
+                Err(err)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn download_zk_nym(
+        &self,
+        pending_request: PendingCredentialRequest,
+    ) -> Result<NymCredential, VpnApiFetcherError> {
+        let pending_request_id = pending_request.id.clone();
         // Poll the nym-vpn-api for the zk-nym ticketbook to be ready. This could take some time,
         // but likely not more than a few seconds.
         let poll_result = self.poll_zk_nym(&pending_request_id).await?;
@@ -167,12 +203,6 @@ impl CredentialRequestTask {
                 self.process_upgrade_mode_response(poll_result).await?
             }
         };
-
-        // Remove the pending request from the storage. We no longer need it.
-        tracing::debug!("Removing pending zk-nym request");
-        self.pending_storage
-            .remove_pending_request(&pending_request_id)
-            .await?;
 
         Ok(success)
     }


### PR DESCRIPTION
## Ticket

https://nymtech.atlassian.net/browse/NYM-1761

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6259)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Credential requests now support epoch-aware processing, enabling requests during credential-generation ceremonies.
  - Verification keys are retrieved for the specific credential epoch.

- **Bug Fixes**
  - Improved handling of epoch mismatches by discarding invalid pending requests and reporting the mismatch.
  - Pending requests are now cleaned up after successful credential completion, reducing stale request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->