### PR TITLE
Restore macOS internet after disconnect without reapplying the kill-switch

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local DNS resolver will respond with `serv_fail` on timeout from upstream DNS server (https://github.com/nymtech/nym-vpn-client/pull/6132)
 - Remove IPv6 DNS addresses from default DNS configuration due to reliability issues (https://github.com/nymtech/nym-vpn-client/pull/6132)
 
+### Fixed
+
+- [macOS] After disconnect, restore DNS and the physical default route and do not re-apply the kill-switch when already disconnected.
+
 
 ## [2026.12.0] - 2026-08-18
 

--- a/nym-vpn-core/crates/nym-dns/src/macos.rs
+++ b/nym-vpn-core/crates/nym-dns/src/macos.rs
@@ -198,25 +198,38 @@ impl State {
     }
 
     fn reset(&mut self, store: &SCDynamicStore) -> Result<()> {
+        tracing::info!("Restoring DNS state from backup");
         tracing::trace!("Restoring DNS settings to: {:#?}", self.backup);
 
         let actual_state = read_all_dns(store);
         self.update_backup_state(&actual_state);
         self.dns_settings.take();
 
-        let old_backup = std::mem::take(&mut self.backup);
+        let backup = mem::take(&mut self.backup);
+        let mut first_error = None;
 
-        for (service_path, settings) in old_backup {
-            if let Some(settings) = settings {
-                settings.save(store, service_path.as_str())?;
-            } else {
-                tracing::debug!("Removing DNS for {} if it exists", service_path);
-                if !store.remove(CFString::new(&service_path)) {
-                    tracing::debug!("DNS for {service_path} doesn't exist in store");
+        for (service_path, settings) in backup {
+            let restore_result = match &settings {
+                Some(settings) => settings.save(store, service_path.as_str()),
+                None => {
+                    tracing::debug!("Removing DNS for {} if it exists", service_path);
+                    if !store.remove(CFString::new(&service_path)) {
+                        tracing::debug!("DNS for {service_path} doesn't exist in store");
+                    }
+                    Ok(())
                 }
+            };
+            if let Err(error) = restore_result {
+                tracing::error!("Failed changing DNS for '{service_path}': {error}");
+                self.backup.insert(service_path, settings);
+                first_error = first_error.or(Some(error));
             }
         }
-        Ok(())
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 }
 
@@ -755,5 +768,27 @@ mod test {
         let merged_state = State::merge_states(&new_state, prev_state, desired_addresses);
 
         assert_eq!(merged_state, expect_state);
+    }
+
+    #[test]
+    fn dns_reset_keeps_failed_backup_entries() {
+        let backup = HashMap::from([
+            ("a".to_owned(), Ok(1)),
+            ("b".to_owned(), Err(2)),
+            ("c".to_owned(), Ok(3)),
+        ]);
+        let mut leftover = HashMap::new();
+        let mut first_error = None;
+        for (path, result) in backup {
+            match result {
+                Ok(_) => {}
+                Err(value) => {
+                    leftover.insert(path, value);
+                    first_error = first_error.or(Some(value));
+                }
+            }
+        }
+        assert_eq!(leftover, HashMap::from([("b".to_owned(), 2)]));
+        assert_eq!(first_error, Some(2));
     }
 }

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -121,6 +121,9 @@ pub struct RouteManagerImpl {
     /// Example: Interface "en0" (1) with IP 192.168.1.222, and with router_ip 192.168.1.1.
     best_default_route: IpMap<interface::DefaultRoute>,
 
+    /// Last non-None physical default per family (monitor may report None after grace timeout).
+    last_physical_default: IpMap<interface::DefaultRoute>,
+
     /// Message to notify `default_route_listeners` when `best_default_route` changes.
     best_default_route_update: IpMap<DefaultRouteEvent>,
 
@@ -175,12 +178,15 @@ impl RouteManagerImpl {
             }
         }
 
+        let last_physical_default = best_default_route.clone();
+
         Ok(Self {
             routing_table,
             non_tunnel_routes: HashSet::new(),
             tunnel_default_routes: IpMap::new(),
             applied_routes: BTreeMap::new(),
             best_default_route,
+            last_physical_default,
             best_default_route_update: IpMap::new(),
             default_route_listeners: vec![],
             best_default_route_rx_v4: best_route_rx_v4,
@@ -513,6 +519,9 @@ impl RouteManagerImpl {
             (interface::Family::V6, false) => DefaultRouteEvent::RemovedV6,
         };
         self.best_default_route_update.insert(family, event);
+        if let Some(ref route) = new_best_route {
+            self.last_physical_default.insert(family, route.clone());
+        }
         self.best_default_route.set(family, new_best_route);
         self.unhandled_default_route_changes = true;
         self.update_trigger.trigger();
@@ -707,7 +716,12 @@ impl RouteManagerImpl {
     /// Add back unscoped default route for the given `family`, if it is still missing. This
     /// function returns true when no route had to be added.
     async fn restore_default_route(&mut self, family: interface::Family) -> bool {
-        let Some(desired_default_route) = self.best_default_route.get(family).cloned() else {
+        let Some(desired_default_route) = self
+            .best_default_route
+            .get(family)
+            .or(self.last_physical_default.get(family))
+            .cloned()
+        else {
             return true;
         };
         let desired_default_route = RouteMessage::from(desired_default_route);
@@ -791,4 +805,39 @@ fn default_route_msg(family: interface::Family) -> RouteMessage {
 fn route_matches_interface(default_route: &RouteMessage, interface_route: &RouteMessage) -> bool {
     default_route.gateway_ip() == interface_route.gateway_ip()
         && default_route.interface_index() == interface_route.interface_index()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn route(interface: &str) -> DefaultRoute {
+        DefaultRoute {
+            interface: interface.to_owned(),
+            interface_index: 14,
+            ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 20)),
+            router_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        }
+    }
+
+    #[test]
+    fn restore_default_route_uses_last_physical_when_current_is_none() {
+        let mut last = IpMap::new();
+        last.insert(interface::Family::V4, route("en0"));
+
+        assert_eq!(
+            None.or(last.get(interface::Family::V4))
+                .map(|r| r.interface.as_str()),
+            Some("en0")
+        );
+
+        let current = route("en1");
+        assert_eq!(
+            Some(&current)
+                .or(last.get(interface::Family::V4))
+                .map(|r| r.interface.as_str()),
+            Some("en1")
+        );
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -1283,6 +1283,7 @@ impl TunnelStateMachine {
             .await
             .is_offline()
         {
+            // No session yet: same as Disconnected while offline (no kill-switch).
             OfflineState::enter(false, None, &mut shared_state).await
         } else {
             DisconnectedState::enter(None, &mut shared_state).await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -42,7 +42,7 @@ impl OfflineState {
             api_endpoints: vec![],
         };
 
-        // reconnect=false: user already disconnected; do not re-apply kill-switch DNS/pf.
+        // reconnect=false: no session (boot/Disconnected/user Disconnect); restore like Disconnected. reconnect=true stays leak-safe.
         if reconnect {
             shared_state.disallow_networking().await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -42,7 +42,7 @@ impl OfflineState {
             api_endpoints: vec![],
         };
 
-        // reconnect=false: no session (boot/Disconnected/user Disconnect); restore like Disconnected. reconnect=true stays leak-safe.
+        // reconnect=false: no active session to protect (cold start, disconnected, or explicit disconnect); reconnect=true stays leak-safe.
         if reconnect {
             shared_state.disallow_networking().await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -35,13 +35,6 @@ impl OfflineState {
         selected_gateways: Option<SelectedGateways>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        shared_state.disallow_networking().await;
-
-        #[cfg(target_os = "macos")]
-        if Self::set_local_dns_resolver(shared_state).await.is_err() {
-            return Box::pin(ErrorState::enter(ErrorStateReason::SetDns, shared_state)).await;
-        }
-
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let firewall_policy_params = BlockedPolicyParameters {
             enable_ipv6: shared_state.tunnel_settings.enable_ipv6,
@@ -49,9 +42,26 @@ impl OfflineState {
             api_endpoints: vec![],
         };
 
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if let Err(e) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
-            trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
+        // reconnect=false: user already disconnected; do not re-apply kill-switch DNS/pf.
+        if reconnect {
+            shared_state.disallow_networking().await;
+
+            #[cfg(target_os = "macos")]
+            if Self::set_local_dns_resolver(shared_state).await.is_err() {
+                return Box::pin(ErrorState::enter(ErrorStateReason::SetDns, shared_state)).await;
+            }
+
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            if let Err(e) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
+                trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
+            }
+        } else {
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            {
+                Self::reset_dns(shared_state).await;
+                Self::reset_firewall_policy(shared_state);
+            }
+            shared_state.allow_networking().await;
         }
 
         (
@@ -151,6 +161,12 @@ impl TunnelStateHandler for OfflineState {
                         {
                             if self.reconnect {
                                 self.reconnect = false;
+                                #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                                {
+                                    Self::reset_dns(shared_state).await;
+                                    Self::reset_firewall_policy(shared_state);
+                                }
+                                shared_state.allow_networking().await;
                                 let new_state = PrivateTunnelState::Offline { reconnect: self.reconnect };
                                 NextTunnelState::NewState((self, new_state))
                             } else {
@@ -189,7 +205,9 @@ impl TunnelStateHandler for OfflineState {
                             if diff.allow_lan_changed() {
                                 self.firewall_policy_params.allow_lan = shared_state.tunnel_settings.allow_lan;
 
-                                if let Err(e) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params) {
+                                if self.reconnect
+                                    && let Err(e) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params)
+                                {
                                     trace_err_chain!(e, "failed to set firewall policy");
                                 }
                             }


### PR DESCRIPTION
- After a user disconnect, macOS no longer reapplies drop-all firewall and local DNS when the daemon reports offline.
- Default-route restore keeps the last physical gateway instead of treating a missing route as already restored.
- DNS restore continues after a single service save failure and keeps failed backup entries for retry.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6261)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS disconnect behavior so DNS settings and the physical default route are restored reliably.
  * Prevented the kill switch from being reapplied when already disconnected.
  * Improved recovery when restoring DNS settings fails by continuing other restoration attempts and retrying failed items later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->