### PR TITLE
[Android] Add status handling for Notification Manager

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved account signup and subscription flow (https://github.com/nymtech/nym-vpn-client/pull/6014)
 
+### Fixed
+- Proper status handling for Notification Manager (https://github.com/nymtech/nym-vpn-client/pull/6268)
+
 ## [2026.12.0] - TBD
 
 ### Added

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -66,7 +66,8 @@ class VpnCoreController(
 
 	@Volatile
 	var currentExit: ExitPoint? = null
-		private set
+
+	private var lastRetryAttempt: UInt? = null
 
 	@get:Synchronized
 	@set:Synchronized
@@ -218,7 +219,7 @@ class VpnCoreController(
 				currentEntry = event.v1.entryPoint
 				currentExit = event.v1.exitPoint
 				events.tryEmit(Log("TunnelEvent config_changed"))
-				service.updateForegroundNotification(state)
+				service.updateForegroundNotification(state, lastRetryAttempt)
 			}
 			is TunnelEvent.DiagnosticsSuggested -> events.tryEmit(Log("TunnelEvent diagnostics_suggested"))
 		}
@@ -230,36 +231,34 @@ class VpnCoreController(
 
 		when (val ts = event.v1) {
 			is TunnelState.Connecting ->
-				events.tryEmit(VpnServiceEvent.EstablishConnection(ts.state, ts.connectionData))
+				events.tryEmit(EstablishConnection(ts.state, ts.connectionData))
 
 			is TunnelState.Connected ->
-				events.tryEmit(VpnServiceEvent.Connected(ts.connectionData))
+				events.tryEmit(Connected(ts.connectionData))
 
 			is TunnelState.Error ->
-				events.tryEmit(VpnServiceEvent.FatalError(ts.v1))
+				events.tryEmit(FatalError(ts.v1))
 
 			else -> Unit
 		}
 
-		// retryAttempt > 0 on a Connecting event means this is a mid-session reconnect
-		// (e.g. triggered by an entry/exit gateway timeout), not the user's initial connect.
-		val retryAttempt = (event.v1 as? TunnelState.Connecting)?.retryAttempt
-		service.updateForegroundNotification(coarse, retryAttempt)
+		lastRetryAttempt = (event.v1 as? TunnelState.Connecting)?.retryAttempt
+		service.updateForegroundNotification(coarse, lastRetryAttempt)
 	}
 
 	private fun handleMixnetEvent(event: TunnelEvent.MixnetState) {
 		when (val mx = event.v1) {
 			is MixnetEvent.Connection ->
-				events.tryEmit(VpnServiceEvent.MixnetConnectionEvent(mx.v1))
+				events.tryEmit(MixnetConnectionEvent(mx.v1))
 
 			else ->
-				events.tryEmit(VpnServiceEvent.Log("MixnetEvent=${mx::class.java.simpleName}"))
+				events.tryEmit(Log("MixnetEvent=${mx::class.java.simpleName}"))
 		}
 	}
 
 	fun publishState(newState: Tunnel.State) {
 		state = newState
-		events.tryEmit(VpnServiceEvent.StateChanged(newState))
+		events.tryEmit(StateChanged(newState))
 		service.updateForegroundNotification(newState)
 	}
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -218,6 +218,7 @@ class VpnCoreController(
 				currentEntry = event.v1.entryPoint
 				currentExit = event.v1.exitPoint
 				events.tryEmit(Log("TunnelEvent config_changed"))
+				service.updateForegroundNotification(state)
 			}
 			is TunnelEvent.DiagnosticsSuggested -> events.tryEmit(Log("TunnelEvent diagnostics_suggested"))
 		}
@@ -240,7 +241,10 @@ class VpnCoreController(
 			else -> Unit
 		}
 
-		service.updateForegroundNotification(coarse)
+		// retryAttempt > 0 on a Connecting event means this is a mid-session reconnect
+		// (e.g. triggered by an entry/exit gateway timeout), not the user's initial connect.
+		val retryAttempt = (event.v1 as? TunnelState.Connecting)?.retryAttempt
+		service.updateForegroundNotification(coarse, retryAttempt)
 	}
 
 	private fun handleMixnetEvent(event: TunnelEvent.MixnetState) {

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnForegroundController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnForegroundController.kt
@@ -56,7 +56,7 @@ class VpnForegroundController(private val service: VpnService) {
 		}
 	}
 
-	fun updateForegroundNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?) {
+	fun updateForegroundNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?, retryAttempt: UInt? = null) {
 		val nm = VpnNotificationManager.getInstance(service)
 		nm.updateVpnNotification(
 			state = state,
@@ -64,6 +64,7 @@ class VpnForegroundController(private val service: VpnService) {
 			exit = exit,
 			gatewaysEntry = null,
 			gatewaysExit = null,
+			retryAttempt = retryAttempt,
 		)
 	}
 }

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
@@ -237,11 +237,12 @@ class VpnService :
 		connectivity.removeObserver(observer)
 	}
 
-	internal fun updateForegroundNotification(state: Tunnel.State) {
+	internal fun updateForegroundNotification(state: Tunnel.State, retryAttempt: UInt? = null) {
 		foreground.updateForegroundNotification(
 			state = state,
 			entry = core.currentEntry,
 			exit = core.currentExit,
+			retryAttempt = retryAttempt,
 		)
 	}
 }

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/notifications/VpnNotificationManager.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/notifications/VpnNotificationManager.kt
@@ -64,11 +64,15 @@ internal class VpnNotificationManager private constructor(private val context: C
 			?.createNotificationChannel(channel)
 	}
 
-	fun buildVpnNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?, gatewaysEntry: List<NymGateway>?, gatewaysExit: List<NymGateway>?): Notification {
+	fun buildVpnNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?, gatewaysEntry: List<NymGateway>?, gatewaysExit: List<NymGateway>?, retryAttempt: UInt? = null): Notification {
 		setupChannel()
 
 		val title = context.getString(R.string.vpn_notification_title)
-		val stateText = state.toStateText()
+		val stateText = if (state == Tunnel.State.EstablishingConnection && (retryAttempt ?: 0u) > 0u) {
+			context.getString(R.string.state_reconnecting)
+		} else {
+			state.toStateText()
+		}
 
 		val entryText = entry?.let {
 			context.getString(R.string.notification_entry, formatEntry(it, gatewaysEntry))
@@ -122,7 +126,7 @@ internal class VpnNotificationManager private constructor(private val context: C
 	}
 
 	/** Updates/cancels the foreground notification based on [state]. */
-	internal fun updateVpnNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?, gatewaysEntry: List<NymGateway>?, gatewaysExit: List<NymGateway>?) {
+	internal fun updateVpnNotification(state: Tunnel.State, entry: EntryPoint?, exit: ExitPoint?, gatewaysEntry: List<NymGateway>?, gatewaysExit: List<NymGateway>?, retryAttempt: UInt? = null) {
 		withNotificationPermission {
 			val nm = NotificationManagerCompat.from(context)
 			if (state == Tunnel.State.Down) {
@@ -130,7 +134,7 @@ internal class VpnNotificationManager private constructor(private val context: C
 			} else {
 				nm.notify(
 					VPN_FOREGROUND_ID,
-					buildVpnNotification(state, entry, exit, gatewaysEntry, gatewaysExit),
+					buildVpnNotification(state, entry, exit, gatewaysEntry, gatewaysExit, retryAttempt),
 				)
 			}
 		}
@@ -206,8 +210,10 @@ internal class VpnNotificationManager private constructor(private val context: C
 		Tunnel.State.Up -> context.getString(R.string.state_connected)
 		Tunnel.State.InitializingClient -> context.getString(R.string.state_initializing)
 		Tunnel.State.EstablishingConnection -> context.getString(R.string.state_establishing)
+		Tunnel.State.Disconnecting -> context.getString(R.string.state_disconnecting)
+		is Tunnel.State.Offline ->
+			if (this.reconnect) context.getString(R.string.state_reconnecting) else context.getString(R.string.state_offline)
 		is Tunnel.State.Error -> this.reason.toHumanReadableString(context)
-		else -> toString()
 	}
 }
 

--- a/nym-vpn-android/core/src/main/res/values/strings.xml
+++ b/nym-vpn-android/core/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
 	<string name="state_disconnected">Disconnected</string>
 	<string name="state_initializing">Initializing client…</string>
 	<string name="state_establishing">Establishing connection…</string>
+	<string name="state_disconnecting">Disconnecting…</string>
+	<string name="state_reconnecting">Reconnecting…</string>
+	<string name="state_offline">Waiting for network…</string>
 	<string name="notification_entry">Entry: %1$s</string>
 	<string name="notification_exit">Exit: %1$s</string>
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6268)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - VPN notifications now distinguish between connecting and reconnecting states.
  - Notifications display clearer statuses for disconnecting, reconnecting, and waiting for a network.
  - Foreground notifications refresh when VPN configuration changes.
- **Bug Fixes**
  - Improved notification status accuracy during connection retries and offline periods.
- **Documentation**
  - Added an unreleased changelog entry describing the notification status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->