### PR TITLE
Make pinned gateways respect the blacklist. (#6272)

### DIFF
--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
@@ -94,7 +94,7 @@ extension GRPCManager {
         case .performantExitGatewayUnavailable:
             ErrorReason.performantExitGatewayUnavailable
         case .invalidEntryGatewayIdentity:
-            ErrorReason.invalidEntryGatewayCountry
+            ErrorReason.invalidEntryGatewayIdentity
         case .invalidExitGatewayIdentity:
             ErrorReason.invalidExitGatewayIdentity
         case .needFullDiskPermissions:

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Respect the gateway blacklist for "pinned gateways" (https://github.com/nymtech/nym-vpn-client/pull/6272)
+
 ### Fixed
 
 - [macOS] After disconnect, restore DNS and the physical default route and do not re-apply the kill-switch when already disconnected.
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Local DNS resolver will respond with `serv_fail` on timeout from upstream DNS server (https://github.com/nymtech/nym-vpn-client/pull/6132)
 - Remove IPv6 DNS addresses from default DNS configuration due to reliability issues (https://github.com/nymtech/nym-vpn-client/pull/6132)
-
 
 ## [2026.12.0] - 2026-08-18
 
@@ -50,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
 - When no VPN tunnel is active the geo-exclusion feature rejects non-excluded traffic. (https://github.com/nymtech/nym-vpn-client/pull/5872)
 
-
 ## [2026.11.0] - 2026-07-10
 
 ### Added
@@ -71,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [macOS] Disable authentication when flag is set (https://github.com/nymtech/nym-vpn-client/pull/5645)
 - [iOS] Fix metadata endpoint not being reached for exit tunnel (https://github.com/nymtech/nym-vpn-client/pull/5728)
 - Fix going into Connected state when metadata endpoint might not work (https://github.com/nymtech/nym-vpn-client/pull/5750)
-- [Linux] Disable NetworkManager's connectivity check before applying firewall rules (https://github.com/nymtech/nym-vpn-client/pull/5801) 
+- [Linux] Disable NetworkManager's connectivity check before applying firewall rules (https://github.com/nymtech/nym-vpn-client/pull/5801)
 - [iOS] Skip ad-blocking rules that do not block by domain (https://github.com/nymtech/nym-vpn-client/pull/5658)
 - [iOS] Handle sub-domain blocking (https://github.com/nymtech/nym-vpn-client/pull/5810)
 - [macOS] Skip catch-all NAT masquerade when split tunneling is active (macOS >=14.6, <15.1 only). (https://github.com/nymtech/nym-vpn-client/pull/5569)
@@ -80,7 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed mixnet tuning feature flag (https://github.com/nymtech/nym-vpn-client/pull/5581)
-
 
 ## [2026.10.0] - 2026-06-09
 
@@ -103,7 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Windows] Fix a crash when the network reconnected (https://github.com/nymtech/nym-vpn-client/pull/5508)
 - [Linux] LP firewalled by allowed_endpoints (https://github.com/nymtech/nym-vpn-client/pull/5516)
 
-
 ## [1.30] - 2026-05-29
 
 ### Added
@@ -121,20 +121,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable automatic gateway elections and revert back to hard-coded `Explicit` mode (https://github.com/nymtech/nym-vpn-client/pull/5436)
 
-
 ## [1.29.2] - 2026-05-04
 
 ### Fixed
 
 - [Windows] Fix missing IPv4 on mixnet tunnel adapter (https://github.com/nymtech/nym-vpn-client/pull/5206)
 
-
 ## [1.29.1] - 2026-04-29
 
 ### Changed
 
 - Switch platform to patched `2026.7-tola`
-
 
 ## [1.29.0] - 2026-04-29
 
@@ -152,7 +149,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [macOS] Use endpoint-security framework directly instead of parsing eslogger output (https://github.com/nymtech/nym-vpn-client/pull/4749)
 
 ### Fixed
-
 
 - Fix false bandwidth-exceeded errors when the VPN API fair-usage database is temporarily unavailable (https://github.com/nymtech/nym-vpn-client/pull/5217)
 - Fix accounts incorrectly appearing inactive due to malformed API timestamp fields (https://github.com/nymtech/nym-vpn-client/pull/5217)
@@ -177,7 +173,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [macOS] Fix bug in XPC buffering between XPC and gRPC layers (https://github.com/nymtech/nym-vpn-client/pull/4985)
 
-
 ## [1.27.0] - 2026-03-31
 
 - [macOS] XPC as transport layer between clients and daemon (https://github.com/nymtech/nym-vpn-client/pull/4695)
@@ -188,14 +183,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [macOS] XPC client stall when daemon is not running (https://github.com/nymtech/nym-vpn-client/pull/4973)
 
-
 ## [1.26.0] - 2026-03-17
 
 ### Added
 
 - [CLI] `nym-vpnc account set` now uses `--location blockchain`; aliases keep legacy `--mode decentralised` and `--mode decentralized` working.
 - [CLI] `nym-vpnc account obtain-ticketbooks` subcommand renamed (legacy alias `decentralised-obtain-ticketbooks` still works). `--source` (currently parsed but all sources route to smartcontract backend).
-
 
 ## [1.25.0] - 2026-03-02
 
@@ -207,7 +200,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Detect time travel and sleep when obtaining remote time (https://github.com/nymtech/nym-vpn-client/pull/4604)
-
 
 ## [1.24.0] - 2026-02-12
 
@@ -239,7 +231,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Android] Enable debug logs in production builds for core library (https://github.com/nymtech/nym-vpn-client/pull/4405)
 - [Android] Print library logs to file, in addition to the existing logcat (https://github.com/nymtech/nym-vpn-client/pull/4432)
 
-
 ## [1.21.0] - 2025-12-15
 
 ### Added
@@ -261,7 +252,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CLI: remove legacy call to connect the tunnel (https://github.com/nymtech/nym-vpn-client/pull/4094)
 
-
 ## [1.20.0] - 2025-12-01
 
 ### Added
@@ -276,7 +266,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid connection looping by temporarily blacklisting the entry gateway (https://github.com/nymtech/nym-vpn-client/pull/4047)
-
 
 ## [1.19.0] - 2025-11-19
 
@@ -298,7 +287,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove unnecessary DNS resolutions on mobile platforms where there is no configurable firewall. (https://github.com/nymtech/nym-vpn-client/pull/3913)
-
 
 ## [1.18.0] - 2025-11-03
 
@@ -329,7 +317,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make discovery refresh aware of network connectivity (https://github.com/nymtech/nym-vpn-client/pull/3805)
 - Fix database cleanup when forgetting account (https://github.com/nymtech/nym-vpn-client/pull/3825)
 
-
 ## [1.17.0] - 2025-10-17
 
 ### Added
@@ -356,7 +343,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed countries query (https://github.com/nymtech/nym-vpn-client/pull/3523)
 
-
 ## [1.16.0] - 2025-09-26
 
 ### Added
@@ -372,7 +358,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [macOS] Skip filtering loopback traffic to optimize performance (https://github.com/nymtech/nym-vpn-client/pull/3441)
 - Prioritize high performance gateways first, fallback to medium. This rule does not apply when specific gateway is selected explicitly (https://github.com/nymtech/nym-vpn-client/pull/3511)
-
 
 ## [1.15.0] - 2025-09-10
 
@@ -423,14 +408,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [macOS] Bind DNS resolver to random loopback IP on port 53 to fix compatibility issues with other software, notably
   `dig` and `nslookup`. (https://github.com/nymtech/nym-vpn-client/pull/3232)
 
-
 ## [1.13.1] - 2025-07-30
 
 ### Changed
 
 - Update pre-bundled discovery to include account links (https://github.com/nymtech/nym-vpn-client/pull/3167)
 - Reduce noisiness of WireGuard logs (https://github.com/nymtech/nym-vpn-client/pull/3169)
-
 
 ## [1.13.0] - 2025-07-29
 
@@ -442,7 +425,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Box too large futures to fix stackoverflow on Windows (https://github.com/nymtech/nym-vpn-client/pull/3139)
-
 
 ## [1.12.0] - 2025-07-18
 
@@ -475,7 +457,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix tunnel connectivity issues by applying route MTU for multihop
   tunnel (https://github.com/nymtech/nym-vpn-client/pull/3051)
 - Fix prefetching topology not working at no network daemon boot (https://github.com/nymtech/nym-vpn-client/pull/3072)
-
 
 ## [1.11.0] - 2025-06-18
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
@@ -2,13 +2,46 @@ use crate::NodeIdentity;
 use anyhow::{Result, anyhow};
 use std::{
     collections::HashMap,
+    fmt,
     hash::Hash,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 
+/// Why a gateway was added to the blacklist, kept around so the selector can log a useful
+/// message when it later excludes that gateway, instead of just "it's blacklisted".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlacklistReason {
+    /// The WG handshake timed out, or a post-handshake connectivity probe failed, without a
+    /// healthy metadata path ever being established through this gateway acting as exit.
+    ConnectionFailed,
+    /// This entry gateway was blamed after several consecutive pre-handshake connection
+    /// failures while the exit gateway kept changing.
+    EntryBlamedForRepeatedFailures,
+    /// Registration with this gateway failed.
+    RegistrationFailed,
+}
+
+impl fmt::Display for BlacklistReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectionFailed => write!(f, "connection failed"),
+            Self::EntryBlamedForRepeatedFailures => {
+                write!(f, "blamed for repeated pre-handshake failures")
+            }
+            Self::RegistrationFailed => write!(f, "registration failed"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    expiry: Instant,
+    reason: BlacklistReason,
+}
+
 #[derive(Debug, Clone, Default)]
-pub struct BlacklistedGateways(Arc<RwLock<HashMap<NodeIdentity, Instant>>>);
+pub struct BlacklistedGateways(Arc<RwLock<HashMap<NodeIdentity, Entry>>>);
 
 impl BlacklistedGateways {
     const TTL: Duration = Duration::from_mins(20);
@@ -17,12 +50,18 @@ impl BlacklistedGateways {
         Default::default()
     }
 
-    pub fn add(&self, identity: NodeIdentity) -> Result<()> {
+    pub fn add(&self, identity: NodeIdentity, reason: BlacklistReason) -> Result<()> {
         match self.0.write() {
             Ok(mut map) => {
                 let now = Instant::now();
-                map.insert(identity, now + Self::TTL);
-                map.retain(|_, expiry| *expiry >= now); // Housekeeping
+                map.insert(
+                    identity,
+                    Entry {
+                        expiry: now + Self::TTL,
+                        reason,
+                    },
+                );
+                map.retain(|_, entry| entry.expiry >= now); // Housekeeping
                 Ok(())
             }
             Err(e) => Err(anyhow!("Failed to acquire write lock: {e}")),
@@ -34,7 +73,7 @@ impl BlacklistedGateways {
             Ok(mut map) => {
                 let now = Instant::now();
                 map.remove(identity);
-                map.retain(|_, expiry| *expiry >= now); // Housekeeping
+                map.retain(|_, entry| entry.expiry >= now); // Housekeeping
                 Ok(())
             }
             Err(e) => Err(anyhow!("Failed to acquire write lock: {e}")),
@@ -52,11 +91,17 @@ impl BlacklistedGateways {
     }
 
     pub fn exists(&self, identity: &NodeIdentity) -> Result<bool> {
+        Ok(self.reason(identity)?.is_some())
+    }
+
+    /// Returns why `identity` is currently blacklisted, or `None` if it isn't (either never
+    /// added, or its entry has expired).
+    pub fn reason(&self, identity: &NodeIdentity) -> Result<Option<BlacklistReason>> {
         match self.0.read() {
-            Ok(map) => match map.get(identity) {
-                Some(expiry) => Ok(*expiry > Instant::now()),
-                None => Ok(false),
-            },
+            Ok(map) => Ok(map
+                .get(identity)
+                .filter(|entry| entry.expiry > Instant::now())
+                .map(|entry| entry.reason)),
             Err(e) => Err(anyhow!("Failed to acquire read lock: {e}")),
         }
     }
@@ -98,8 +143,25 @@ mod tests {
         let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
 
         assert!(!blacklist.exists(&identity).unwrap());
-        blacklist.add(identity).unwrap();
+        blacklist
+            .add(identity, BlacklistReason::ConnectionFailed)
+            .unwrap();
         assert!(blacklist.exists(&identity).unwrap());
+    }
+
+    #[test]
+    fn test_reason_is_recorded_and_retrievable() {
+        let blacklist = BlacklistedGateways::new();
+        let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
+
+        assert_eq!(blacklist.reason(&identity).unwrap(), None);
+        blacklist
+            .add(identity, BlacklistReason::RegistrationFailed)
+            .unwrap();
+        assert_eq!(
+            blacklist.reason(&identity).unwrap(),
+            Some(BlacklistReason::RegistrationFailed)
+        );
     }
 
     #[test]
@@ -107,7 +169,9 @@ mod tests {
         let blacklist = BlacklistedGateways::new();
         let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
 
-        blacklist.add(identity).unwrap();
+        blacklist
+            .add(identity, BlacklistReason::ConnectionFailed)
+            .unwrap();
         assert!(blacklist.exists(&identity).unwrap());
 
         blacklist.remove(&identity).unwrap();
@@ -120,8 +184,12 @@ mod tests {
         let id1 = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
         let id2 = create_test_identity("HiVGQq2riqPFoPyYRYCZq3zFmFk15gnJzH4s9mHEbgKH");
 
-        blacklist.add(id1).unwrap();
-        blacklist.add(id2).unwrap();
+        blacklist
+            .add(id1, BlacklistReason::ConnectionFailed)
+            .unwrap();
+        blacklist
+            .add(id2, BlacklistReason::ConnectionFailed)
+            .unwrap();
         assert!(!blacklist.is_empty().unwrap());
 
         blacklist.clear().unwrap();
@@ -136,7 +204,9 @@ mod tests {
         assert!(blacklist.is_empty().unwrap());
 
         let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
-        blacklist.add(identity).unwrap();
+        blacklist
+            .add(identity, BlacklistReason::ConnectionFailed)
+            .unwrap();
         assert!(!blacklist.is_empty().unwrap());
 
         blacklist.remove(&identity).unwrap();
@@ -151,11 +221,18 @@ mod tests {
 
         // Add an entry with an expired timestamp
         if let Ok(mut map) = blacklist.0.write() {
-            map.insert(identity, Instant::now() - Duration::from_secs(1));
+            map.insert(
+                identity,
+                Entry {
+                    expiry: Instant::now() - Duration::from_secs(1),
+                    reason: BlacklistReason::ConnectionFailed,
+                },
+            );
         }
 
         // Should return false because the entry is expired
         assert!(!blacklist.exists(&identity).unwrap());
+        assert_eq!(blacklist.reason(&identity).unwrap(), None);
     }
 
     #[test]
@@ -166,11 +243,19 @@ mod tests {
 
         // Add an expired entry manually
         if let Ok(mut map) = blacklist.0.write() {
-            map.insert(id1, Instant::now() - Duration::from_secs(1));
+            map.insert(
+                id1,
+                Entry {
+                    expiry: Instant::now() - Duration::from_secs(1),
+                    reason: BlacklistReason::ConnectionFailed,
+                },
+            );
         }
 
         // Add a new entry, which should trigger housekeeping
-        blacklist.add(id2).unwrap();
+        blacklist
+            .add(id2, BlacklistReason::ConnectionFailed)
+            .unwrap();
 
         // The expired entry should have been cleaned up
         if let Ok(map) = blacklist.0.read() {
@@ -187,12 +272,20 @@ mod tests {
 
         // Add an expired entry manually
         if let Ok(mut map) = blacklist.0.write() {
-            map.insert(id1, Instant::now() - Duration::from_secs(1));
+            map.insert(
+                id1,
+                Entry {
+                    expiry: Instant::now() - Duration::from_secs(1),
+                    reason: BlacklistReason::ConnectionFailed,
+                },
+            );
         } else {
             panic!("Failed to acquire write lock");
         }
 
-        blacklist.add(id2).unwrap();
+        blacklist
+            .add(id2, BlacklistReason::ConnectionFailed)
+            .unwrap();
 
         // Remove id2, which should trigger housekeeping
         blacklist.remove(&id2).unwrap();
@@ -217,14 +310,18 @@ mod tests {
 
         let handle1 = thread::spawn(move || {
             for _ in 0..100 {
-                blacklist_for_thread1.add(id1).unwrap();
+                blacklist_for_thread1
+                    .add(id1, BlacklistReason::ConnectionFailed)
+                    .unwrap();
                 thread::sleep(Duration::from_micros(10));
             }
         });
 
         let handle2 = thread::spawn(move || {
             for _ in 0..100 {
-                blacklist_for_thread2.add(id2).unwrap();
+                blacklist_for_thread2
+                    .add(id2, BlacklistReason::ConnectionFailed)
+                    .unwrap();
                 thread::sleep(Duration::from_micros(10));
             }
         });
@@ -248,7 +345,9 @@ mod tests {
         let blacklist_clone = blacklist.clone();
         let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
 
-        blacklist.add(identity).unwrap();
+        blacklist
+            .add(identity, BlacklistReason::ConnectionFailed)
+            .unwrap();
 
         // Clone should see the same state
         assert!(blacklist_clone.exists(&identity).unwrap());

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -212,8 +212,15 @@ impl Gateway {
     }
 
     pub fn is_whitelisted(&self, blacklisted_gateways: &BlacklistedGateways) -> bool {
-        match blacklisted_gateways.exists(&self.identity) {
-            Ok(exists) => !exists,
+        match blacklisted_gateways.reason(&self.identity) {
+            Ok(Some(reason)) => {
+                tracing::debug!(
+                    "Excluding gateway {} from selection: blacklisted ({reason})",
+                    self.identity
+                );
+                false
+            }
+            Ok(None) => true,
             Err(e) => {
                 tracing::error!("Error testing gateway whitelisting: {e}");
                 false
@@ -820,11 +827,21 @@ impl GatewayList {
         match &entry_point {
             EntryPoint::Gateway { identity } => {
                 tracing::debug!("Selecting gateway by identity: {identity}");
-                self.gateway_with_identity(identity)
-                    .ok_or_else(|| Error::NoMatchingGateway {
-                        requested_identity: identity.to_string(),
+                // Score tiering doesn't apply to a pinned identity: there's only one
+                // candidate, so `optional_filters` (MinScore) is deliberately not applied
+                // here, only the caller's real constraints (e.g. NotBlacklisted).
+                self.gateway_with_identity_filtered(identity, base_filters)
+                    .ok_or_else(|| {
+                        if self.gateway_with_identity(identity).is_some() {
+                            Error::GatewayFilteredOut {
+                                requested_identity: identity.to_string(),
+                            }
+                        } else {
+                            Error::NoMatchingGateway {
+                                requested_identity: identity.to_string(),
+                            }
+                        }
                     })
-                    .cloned()
             }
             EntryPoint::Country {
                 two_letter_iso_country_code,
@@ -951,21 +968,35 @@ impl GatewayList {
 
                 // Now fetch the gateway that the IPR is connected to, and override its IPR address
                 let mut gateway = self
-                    .gateway_with_identity(&gateway_address)
-                    .ok_or_else(|| Error::NoMatchingGateway {
-                        requested_identity: gateway_address.to_string(),
-                    })
-                    .cloned()?;
+                    .gateway_with_identity_filtered(&gateway_address, base_filters)
+                    .ok_or_else(|| {
+                        if self.gateway_with_identity(&gateway_address).is_some() {
+                            Error::GatewayFilteredOut {
+                                requested_identity: gateway_address.to_string(),
+                            }
+                        } else {
+                            Error::NoMatchingGateway {
+                                requested_identity: gateway_address.to_string(),
+                            }
+                        }
+                    })?;
                 gateway.ipr_address = Some(ipr_address);
                 Ok(gateway)
             }
             ExitPoint::Gateway { identity } => {
                 tracing::debug!("Selecting exit gateway by identity: {identity}");
-                self.gateway_with_identity(identity)
-                    .ok_or_else(|| Error::NoMatchingGateway {
-                        requested_identity: identity.to_string(),
+                self.gateway_with_identity_filtered(identity, base_filters)
+                    .ok_or_else(|| {
+                        if self.gateway_with_identity(identity).is_some() {
+                            Error::GatewayFilteredOut {
+                                requested_identity: identity.to_string(),
+                            }
+                        } else {
+                            Error::NoMatchingGateway {
+                                requested_identity: identity.to_string(),
+                            }
+                        }
                     })
-                    .cloned()
             }
             ExitPoint::Country {
                 two_letter_iso_country_code,
@@ -1014,6 +1045,15 @@ impl GatewayList {
         exit_point: &ExitPoint,
         base_filters: &GatewayFilters,
     ) -> Result<Gateway> {
+        if matches!(
+            exit_point,
+            ExitPoint::Gateway { .. } | ExitPoint::Address { .. }
+        ) {
+            // A specific gateway/address has exactly one candidate, so score tiering can
+            // only ever exclude it, never help find it: apply the caller's real
+            // constraints (e.g. NotBlacklisted) without the MinScore tiers.
+            return self.find_exit_gateway(exit_point, base_filters);
+        }
         for score in [ScoreValue::High, ScoreValue::Medium, ScoreValue::Low] {
             tracing::debug!("Looking for entry gateway with minimum score: {score}");
 
@@ -1058,6 +1098,15 @@ impl GatewayList {
         exit_point: &ExitPoint,
         base_filters: &GatewayFilters,
     ) -> Result<Gateway> {
+        if matches!(
+            exit_point,
+            ExitPoint::Gateway { .. } | ExitPoint::Address { .. }
+        ) {
+            // A specific gateway/address has exactly one candidate, so score tiering can
+            // only ever exclude it, never help find it: apply the caller's real
+            // constraints (e.g. NotBlacklisted) without the MinSocks5Score tiers.
+            return self.find_exit_gateway(exit_point, base_filters);
+        }
         for score in [ScoreValue::High, ScoreValue::Medium, ScoreValue::Low] {
             tracing::debug!("Looking for exit gateway with minimum SOCKS5 score: {score}");
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::BlacklistReason;
 
 #[test]
 fn test_matching_mixnet_score() {
@@ -309,7 +310,9 @@ fn test_gateway_non_blacklisted() {
 
     let blacklisted = gateway_list.gateways[3].identity;
     let blacklisted_gateways = BlacklistedGateways::new();
-    blacklisted_gateways.add(blacklisted).unwrap();
+    blacklisted_gateways
+        .add(blacklisted, BlacklistReason::ConnectionFailed)
+        .unwrap();
 
     for _ in 0..64 {
         let chosen = gateway_list
@@ -319,6 +322,70 @@ fn test_gateway_non_blacklisted() {
             .unwrap();
         assert_ne!(chosen.identity, blacklisted);
     }
+}
+
+#[test]
+fn test_pinned_entry_gateway_respects_blacklist() {
+    let gateway_list = sample_gateway_list(GatewayType::Wg);
+    let pinned = gateway_list.gateways[0].identity;
+
+    let blacklisted_gateways = BlacklistedGateways::new();
+    blacklisted_gateways
+        .add(pinned, BlacklistReason::ConnectionFailed)
+        .unwrap();
+    let filters = GatewayFilters::from(&[GatewayFilter::NotBlacklisted(blacklisted_gateways)]);
+
+    let entry_point = EntryPoint::Gateway {
+        identity: pinned.into(),
+    };
+    let err = gateway_list
+        .find_best_entry_point_gateway(&entry_point, &filters)
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::GatewayFilteredOut { .. }),
+        "expected GatewayFilteredOut, got {err:?}"
+    );
+}
+
+#[test]
+fn test_pinned_exit_gateway_respects_blacklist() {
+    let gateway_list = sample_gateway_list(GatewayType::MixnetExit);
+    let pinned = gateway_list.gateways[0].identity;
+
+    let blacklisted_gateways = BlacklistedGateways::new();
+    blacklisted_gateways
+        .add(pinned, BlacklistReason::ConnectionFailed)
+        .unwrap();
+    let filters = GatewayFilters::from(&[GatewayFilter::NotBlacklisted(blacklisted_gateways)]);
+
+    let exit_point = ExitPoint::Gateway {
+        identity: pinned.into(),
+    };
+    let err = gateway_list
+        .find_best_exit_point_gateway(&exit_point, &filters)
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::GatewayFilteredOut { .. }),
+        "expected GatewayFilteredOut, got {err:?}"
+    );
+}
+
+#[test]
+fn test_pinned_gateway_not_in_directory_is_no_matching_gateway() {
+    let gateway_list = sample_gateway_list(GatewayType::Wg);
+    let unknown =
+        NodeIdentity::from_base58_string("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42").unwrap();
+
+    let entry_point = EntryPoint::Gateway {
+        identity: unknown.into(),
+    };
+    let err = gateway_list
+        .find_best_entry_point_gateway(&entry_point, &GatewayFilters::default())
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::NoMatchingGateway { .. }),
+        "expected NoMatchingGateway, got {err:?}"
+    );
 }
 
 #[test]

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
     #[error("no matching gateway found: {requested_identity}")]
     NoMatchingGateway { requested_identity: String },
 
+    #[error("gateway {requested_identity} exists but is currently excluded from selection")]
+    GatewayFilteredOut { requested_identity: String },
+
     #[error(
         "no entry gateway available for location {requested_location}, available countries: {available_countries:?}"
     )]

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -12,7 +12,7 @@ pub use nym_sdk::mixnet::{NodeIdentity, Recipient};
 pub use nym_vpn_api_client::types::{GatewayMinPerformance, NaiveFloat, Percent};
 
 pub use crate::{
-    blacklisted_gateways::BlacklistedGateways,
+    blacklisted_gateways::{BlacklistReason, BlacklistedGateways},
     entries::{
         auth_addresses::AuthAddress,
         country::Country,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -1511,12 +1511,23 @@ impl tunnel::Error {
                 GatewayProviderError::SameEntryAndExitGateway { .. } => {
                     Some(ErrorStateReason::SameEntryAndExitGateway)
                 }
-                GatewayProviderError::EntryGatewayUnavailable { .. } => {
-                    Some(ErrorStateReason::PerformantEntryGatewayUnavailable)
-                }
-                GatewayProviderError::ExitGatewayUnavailable { .. } => {
-                    Some(ErrorStateReason::PerformantExitGatewayUnavailable)
-                }
+                GatewayProviderError::EntryGatewayUnavailable(err) => Some(match err {
+                    // Only ever returned for a pinned entry gateway identity: it exists but
+                    // is currently excluded from selection (e.g. blacklisted), or doesn't
+                    // exist at all. Either way, the fix is the same: pick a different one.
+                    nym_gateway_directory::Error::NoMatchingGateway { .. }
+                    | nym_gateway_directory::Error::GatewayFilteredOut { .. } => {
+                        ErrorStateReason::InvalidEntryGatewayIdentity
+                    }
+                    _ => ErrorStateReason::PerformantEntryGatewayUnavailable,
+                }),
+                GatewayProviderError::ExitGatewayUnavailable(err) => Some(match err {
+                    nym_gateway_directory::Error::NoMatchingGateway { .. }
+                    | nym_gateway_directory::Error::GatewayFilteredOut { .. } => {
+                        ErrorStateReason::InvalidExitGatewayIdentity
+                    }
+                    _ => ErrorStateReason::PerformantExitGatewayUnavailable,
+                }),
                 GatewayProviderError::NeedsRelaxedIndependenceCriteria => {
                     Some(ErrorStateReason::NeedsRelaxedIndependenceCriteria)
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -37,7 +37,7 @@ use nym_firewall::{
     AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, Endpoint, FirewallPolicy,
     TransportProtocol,
 };
-use nym_gateway_directory::ResolvedConfig;
+use nym_gateway_directory::{BlacklistReason, ResolvedConfig};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -762,7 +762,10 @@ impl TunnelStateHandler for ConnectingState {
                     TunnelMonitorEvent::ConnectionFailed { entry_gateway_id, exit_gateway_id, exit_handshake_completed } => {
                         // WG handshake timed out or connectivity probe failed without a healthy
                         // metadata path; blacklist the exit so a different one is selected.
-                        shared_state.gateway_provider.add_blacklisted_gateway(exit_gateway_id).await;
+                        shared_state.gateway_provider.add_blacklisted_gateway(
+                            exit_gateway_id,
+                            BlacklistReason::ConnectionFailed,
+                        ).await;
                         // A failure before the exit handshake ever completed may equally be the
                         // entry gateway's fault. Once the same entry accumulates enough
                         // pre-handshake failures while exits rotate, blacklist it too.
@@ -770,7 +773,10 @@ impl TunnelStateHandler for ConnectingState {
                             tracing::warn!(
                                 "Blacklisted entry gateway {entry_gateway_id} after repeated connection failures without a completed exit handshake"
                             );
-                            shared_state.gateway_provider.add_blacklisted_gateway(entry_gateway_id).await;
+                            shared_state.gateway_provider.add_blacklisted_gateway(
+                                entry_gateway_id,
+                                BlacklistReason::EntryBlamedForRepeatedFailures,
+                            ).await;
                         }
                         self.selected_gateways = None;
                         NextTunnelState::SameState(self)
@@ -778,7 +784,10 @@ impl TunnelStateHandler for ConnectingState {
                     TunnelMonitorEvent::RegistrationFailed { gateway_id } => {
                         // Registration with the entry gateway failed; blacklist it to avoid
                         // re-selecting the same failing gateway.
-                        shared_state.gateway_provider.add_blacklisted_gateway(gateway_id).await;
+                        shared_state.gateway_provider.add_blacklisted_gateway(
+                            gateway_id,
+                            BlacklistReason::RegistrationFailed,
+                        ).await;
                         self.selected_gateways = None;
                         NextTunnelState::SameState(self)
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 use std::{sync::Arc, task::Poll, time::Duration};
 
 use futures::{FutureExt as _, Stream, StreamExt as FuturesStreamExt};
-use nym_gateway_directory::{BlacklistedGateways, GatewayClient, NodeIdentity};
+use nym_gateway_directory::{BlacklistReason, BlacklistedGateways, GatewayClient, NodeIdentity};
 use nym_vpn_lib_types::TentativeGateways;
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::{
@@ -293,17 +293,18 @@ impl<C: GatewayCache> GatewayProvider<C> {
         self.blacklisted_gateways.clone()
     }
 
-    pub async fn add_blacklisted_gateway(&self, gateway_identifier: NodeIdentity) {
-        if let Err(e) = self.blacklisted_gateways.add(gateway_identifier) {
+    pub async fn add_blacklisted_gateway(
+        &self,
+        gateway_identifier: NodeIdentity,
+        reason: BlacklistReason,
+    ) {
+        if let Err(e) = self.blacklisted_gateways.add(gateway_identifier, reason) {
             tracing::error!(
                 "Failed to add gateway {} to blacklisted gateway list: {e}",
                 gateway_identifier
             );
         } else {
-            tracing::warn!(
-                "Blacklisted gateway {} due to connection or registration failure",
-                gateway_identifier
-            );
+            tracing::warn!("Blacklisted gateway {gateway_identifier} ({reason})");
             // Re-create gateway selection stream to reflect the addition to the blacklist.
             let latest_tunnel_settings = self.latest_tunnel_settings.lock().await.clone();
             let _ = self.set_tunnel_settings(latest_tunnel_settings)


### PR DESCRIPTION
A pinned entry/exit gateway identity bypassed all selection filters (`NotBlacklisted`, `MinScore`, `Residential`, ...) via an unfiltered lookup, so a user who pinned a gateway that was actively being blocked (e.g. GFW UDP blackholing) would retry the same doomed gateway on every connection attempt forever, with no cooldown and no useful error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6275)
<!-- Reviewable:end -->
