### PR TITLE
Dynamic DNS Fallbacks based on NetworkDetails

### DIFF
--- a/nym-vpn-app/src-tauri/src/tray/linux.rs
+++ b/nym-vpn-app/src-tauri/src/tray/linux.rs
@@ -35,7 +35,7 @@ fn decode_argb(bytes: &[u8]) -> ksni::Icon {
     let height = img.height() as i32;
     let mut data = img.into_rgba8().into_vec();
     // ksni expects ARGB; image gives RGBA.
-    for px in data.chunks_exact_mut(4) {
+    for px in data.as_chunks_mut::<4>().0 {
         px.rotate_right(1);
     }
     ksni::Icon {

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration profiles: Safest, Most Private, Fastest and Random (https://github.com/nymtech/nym-vpn-client/pull/6073)
 - Pin zk-nym credential requests to the DKG epoch (https://github.com/nymtech/nym-vpn-client/pull/6259)
 - Respect the gateway blacklist for "pinned gateways" (https://github.com/nymtech/nym-vpn-client/pull/6272)
+- Add end-to-end plumbing for dynamically applying DNS fallbacks from NetworkDetails (https://github.com/nymtech/nym-vpn-client/pull/6279)
 - Verify the entry handshake and blacklist entry early if needed (https://github.com/nymtech/nym-vpn-client/pull/6308)
 - Add `six_months` subscription kind to the vpn-api models and gRPC proto (https://github.com/nymtech/nym-vpn-client/pull/6320)
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7839,6 +7839,7 @@ dependencies = [
  "nym-ip-packet-requests",
  "nym-lp",
  "nym-macos",
+ "nym-network-defaults",
  "nym-offline-monitor",
  "nym-platform-metadata",
  "nym-registration-client",

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -50,7 +50,7 @@ impl MixnetClientRegistration {
         tracing::info!("Starting mixnet client");
 
         let disconnected_mixnet_client = match Self::build_mixnet_client(
-            network.nym_network_details().clone(),
+            network.nym_network_details().clone().into(),
             &parameters.gateway,
             Box::new(topology_provider),
         ) {

--- a/nym-vpn-core/crates/nym-diagnostic/src/main.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
             .fetch_network_details()
             .await
             .context("Failed to build non mainnet env : network details")?;
-        crate::Network::new_from_discovery(discovery, (*network_details).into())
+        crate::Network::new_from_discovery(discovery, *network_details)
             .context("Failed to build non mainnet env : build")?
     } else {
         bail!("Unknown network name");

--- a/nym-vpn-core/crates/nym-diagnostic/src/main.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
             .fetch_network_details()
             .await
             .context("Failed to build non mainnet env : network details")?;
-        crate::Network::new_from_discovery(discovery, *network_details)
+        crate::Network::new_from_discovery(discovery, (*network_details).into())
             .context("Failed to build non mainnet env : build")?
     } else {
         bail!("Unknown network name");

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -335,9 +335,7 @@ fn test_pinned_entry_gateway_respects_blacklist() {
         .unwrap();
     let filters = GatewayFilters::from(&[GatewayFilter::NotBlacklisted(blacklisted_gateways)]);
 
-    let entry_point = EntryPoint::Gateway {
-        identity: pinned.into(),
-    };
+    let entry_point = EntryPoint::Gateway { identity: pinned };
     let err = gateway_list
         .find_best_entry_point_gateway(&entry_point, &filters)
         .unwrap_err();
@@ -358,9 +356,7 @@ fn test_pinned_exit_gateway_respects_blacklist() {
         .unwrap();
     let filters = GatewayFilters::from(&[GatewayFilter::NotBlacklisted(blacklisted_gateways)]);
 
-    let exit_point = ExitPoint::Gateway {
-        identity: pinned.into(),
-    };
+    let exit_point = ExitPoint::Gateway { identity: pinned };
     let err = gateway_list
         .find_best_exit_point_gateway(&exit_point, &filters)
         .unwrap_err();
@@ -376,9 +372,7 @@ fn test_pinned_gateway_not_in_directory_is_no_matching_gateway() {
     let unknown =
         NodeIdentity::from_base58_string("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42").unwrap();
 
-    let entry_point = EntryPoint::Gateway {
-        identity: unknown.into(),
-    };
+    let entry_point = EntryPoint::Gateway { identity: unknown };
     let err = gateway_list
         .find_best_entry_point_gateway(&entry_point, &GatewayFilters::default())
         .unwrap_err();

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -204,7 +204,7 @@ impl GatewayClient {
     // except it uses the network_details.nym_vpn_api_urls to create the vpn_api_client.
     pub async fn from_network(
         config: Config,
-        network_details: &nym_network_defaults::NymNetworkDetails,
+        network_details: &nym_network_defaults::v2::NymNetworkDetails,
         user_agent: UserAgent,
     ) -> Result<Self> {
         let nym_urls = api_urls_to_urls(&config.nym_api_urls)?;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/nyxd_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/nyxd_client.rs
@@ -28,9 +28,10 @@ impl NyxdClient {
         if self.client.is_some() {
             return Ok(());
         }
-        let network_details = self.network.nym_network_details();
+        let network_details: nym_sdk::NymNetworkDetails =
+            self.network.nym_network_details().clone().into();
         let client_config =
-            Config::try_from_nym_network_details(network_details).map_err(|err| {
+            Config::try_from_nym_network_details(&network_details).map_err(|err| {
                 AccountCommandError::NyxdConnectionFailure(format!(
                     "invalid network information: {err}"
                 ))

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -111,14 +111,12 @@ impl VpnApiClient {
         network: &nym_network_defaults::v2::NymNetworkDetails,
         user_agent: Option<UserAgent>,
     ) -> Result<Self> {
-        #[allow(deprecated)]
         let api_urls = network.nym_vpn_api_urls();
         if api_urls.is_empty() {
-            let err: HttpClientError = HttpClientError::GenericRequestFailure(
-                "No Nym VPN API URLs configured in network details".to_string(),
-            );
-            return Err(VpnApiClientError::CreateVpnApiClient(Box::new(err)));
-        };
+            return Err(VpnApiClientError::CreateVpnApiClient(Box::new(
+                HttpClientError::NoUrlsProvided,
+            )));
+        }
 
         let urls = api_urls_to_urls(&api_urls)?;
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -108,18 +108,19 @@ impl VpnApiClient {
 
     #[cfg(feature = "network-defaults")]
     pub async fn from_network(
-        network: &nym_network_defaults::NymNetworkDetails,
+        network: &nym_network_defaults::v2::NymNetworkDetails,
         user_agent: Option<UserAgent>,
     ) -> Result<Self> {
         #[allow(deprecated)]
-        let api_urls = network.nym_vpn_api_urls.as_ref().ok_or_else(|| {
+        let api_urls = network.nym_vpn_api_urls();
+        if api_urls.is_empty() {
             let err: HttpClientError = HttpClientError::GenericRequestFailure(
                 "No Nym VPN API URLs configured in network details".to_string(),
             );
-            VpnApiClientError::CreateVpnApiClient(Box::new(err))
-        })?;
+            return Err(VpnApiClientError::CreateVpnApiClient(Box::new(err)));
+        };
 
-        let urls = api_urls_to_urls(api_urls)?;
+        let urls = api_urls_to_urls(&api_urls)?;
 
         let inner =
             fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -89,9 +89,9 @@ pub use gateway::{
 pub use gateway_independence::GatewayIndependence;
 pub use gateway_selection_algorithm::GatewaySelectionAlgorithmConfig;
 pub use network::{
-    ApiUrl, ChainDetails, DenomDetailsOwned, FeatureFlags, FlagValue, Network,
-    NetworkCompatibility, NymContracts, NymNetworkDetails, NymVpnNetwork, ParsedAccountLinks,
-    SystemConfiguration, SystemMessage, ValidatorDetails,
+    ApiUrl, ChainDetails, DenomDetailsOwned, DnsFallback, FeatureFlags, FlagValue, Network,
+    NetworkCompatibility, NymContracts, NymNetworkDetails, NymNetworkingSpecifics, NymVpnNetwork,
+    ParsedAccountLinks, SystemConfiguration, SystemMessage, ValidatorDetails,
 };
 pub use network_stats::{NetworkStatisticsConfig, NetworkStatisticsIdentity};
 pub use paths::LogPath;

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
@@ -24,9 +24,40 @@ pub struct NymNetworkDetails {
     pub chain_details: ChainDetails,
     pub endpoints: Vec<ValidatorDetails>,
     pub contracts: NymContracts,
-    pub nym_vpn_api_url: Option<String>,
-    pub nym_api_urls: Option<Vec<ApiUrl>>,
-    pub nym_vpn_api_urls: Option<Vec<ApiUrl>>,
+    pub networking: NymNetworkingSpecifics,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct NymNetworkingSpecifics {
+    pub nym_api_urls: Vec<ApiUrl>,
+    pub nym_vpn_api_urls: Vec<ApiUrl>,
+    pub dns_fallbacks: Vec<DnsFallback>,
+    // pub internal_nameservers: std::any::Any,
+    // pub covert channels: std::any::Any,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct DnsFallback {
+    pub url: String,
+    pub addresses: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -408,13 +439,36 @@ impl From<nym_vpn_network_config::NymNetworkDetails> for NymNetworkDetails {
                 .map(ValidatorDetails::from)
                 .collect(),
             contracts: NymContracts::from(value.contracts),
-            nym_vpn_api_url: value.nym_vpn_api_url,
-            nym_api_urls: value
-                .nym_api_urls
-                .map(|v| v.into_iter().map(ApiUrl::from).collect::<Vec<_>>()),
+            networking: value.networking.clone().into(),
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
+impl From<nym_network_defaults::v2::NetworkingSpecifics> for NymNetworkingSpecifics {
+    fn from(value: nym_network_defaults::v2::NetworkingSpecifics) -> Self {
+        Self {
+            nym_api_urls: value.nym_api_urls.into_iter().map(ApiUrl::from).collect(),
             nym_vpn_api_urls: value
                 .nym_vpn_api_urls
-                .map(|v| v.into_iter().map(ApiUrl::from).collect::<Vec<_>>()),
+                .into_iter()
+                .map(ApiUrl::from)
+                .collect(),
+            dns_fallbacks: value
+                .dns_fallbacks
+                .into_iter()
+                .map(DnsFallback::from)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
+impl From<nym_network_defaults::v2::DnsFallback> for DnsFallback {
+    fn from(value: nym_network_defaults::v2::DnsFallback) -> Self {
+        Self {
+            url: value.url,
+            addresses: value.addresses,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -65,6 +65,7 @@ nym-platform-metadata = { workspace = true, features = ["user-agent-macro"] }
 nym-connection-monitor.workspace = true
 nym-gateway-directory.workspace = true
 nym-ip-packet-client.workspace = true
+nym-network-defaults.workspace = true
 nym-offline-monitor.workspace = true
 nym-registration-client.workspace = true
 nym-registration-common.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/lazy_socks5.rs
@@ -3,10 +3,8 @@
 use super::util::ConnectionGuard;
 use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_gateway_directory::{GatewayCacheHandle, ScoreValue};
-use nym_sdk::{
-    NymNetworkDetails,
-    mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient, StoragePaths},
-};
+use nym_network_defaults::v2::NymNetworkDetails;
+use nym_sdk::mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient, StoragePaths};
 use nym_vpn_lib_types::{TunnelConnectionData, TunnelState};
 use rand::seq::SliceRandom;
 use std::{
@@ -540,7 +538,7 @@ impl LazySocks5 {
 
         // Configure network environment if provided
         if let Some(ref network_details) = self.config.network_details {
-            builder = builder.network_details(network_details.clone());
+            builder = builder.network_details(network_details.clone().into());
             debug!(
                 "Using network environment: {}",
                 network_details.network_name

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/mod.rs
@@ -16,7 +16,7 @@ use http_rpc::HttpRpc;
 use lazy_socks5::{LazySocks5, LazySocks5Config, LazySocks5Error};
 use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_gateway_directory::GatewayCacheHandle;
-use nym_sdk::NymNetworkDetails;
+use nym_network_defaults::v2::NymNetworkDetails;
 use nym_vpn_lib_types::TunnelState;
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::RwLock, task::JoinHandle};

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -33,6 +33,7 @@ use tokio_util::sync::CancellationToken;
 use nym_common::trace_err_chain;
 use nym_favorites::RecentsManager;
 use nym_gateway_directory::{GatewayFilter, GatewayFilters, GatewayList};
+use nym_http_api_client::HickoryDnsResolver;
 use nym_statistics::{
     StatisticsCommandsSender, StatisticsController, StatisticsControllerError, StatisticsSender,
 };
@@ -453,6 +454,14 @@ impl NymVpnService {
         let network_env = network_cache
             .network()
             .map_err(|_| Error::NetworkEnvNotInitialized)?;
+
+        HickoryDnsResolver::shared().set_fallback_addrs(
+            network_env
+                .dns_fallback_addr_map()
+                .into_iter()
+                .map(|(host, addrs)| (host, addrs.into_iter().collect()))
+                .collect(),
+        );
 
         let network_name = network_env.nym_network_details().network_name.clone();
 
@@ -1004,6 +1013,11 @@ impl NymVpnService {
     }
 
     async fn handle_network_change(&mut self, new_network: Box<Network>) {
+        if !self.maybe_update_active_network_details(&new_network) {
+            tracing::debug!("Network environment unchanged, skipping cache refresh");
+            return;
+        }
+
         tracing::info!("Network environment updated");
         let _ = self.network_tx.send_replace(new_network.clone());
 
@@ -1015,6 +1029,25 @@ impl NymVpnService {
             &self.user_agent,
         )
         .await;
+    }
+
+    /// Updates the currently active network environment if `new_network` differs from it.
+    /// Returns whether an update was applied.
+    fn maybe_update_active_network_details(&mut self, new_network: &Network) -> bool {
+        if self.network_tx.borrow().as_ref() == new_network {
+            return false;
+        }
+
+        let addrs = new_network
+            .dns_fallback_addr_map()
+            .into_iter()
+            .map(|(host, addrs)| (host, addrs.into_iter().collect()))
+            .collect();
+
+        HickoryDnsResolver::shared().set_fallback_addrs(addrs);
+
+        let _ = self.network_tx.send_replace(Box::new(new_network.clone()));
+        true
     }
 
     // Wrap handle_service_command in timing code to log long-running commands

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -2605,7 +2605,8 @@ mod tests {
             count.load(Ordering::SeqCst),
             2,
             "two independent publishes of the same state must show up as two notifications, \
-             proving the earlier test would fail if the duplicate publish returned"
+             proving the network_change_publishes_update_exactly_once would fail if the \
+             duplicate publish returned"
         );
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1013,13 +1013,12 @@ impl NymVpnService {
     }
 
     async fn handle_network_change(&mut self, new_network: Box<Network>) {
-        if !self.maybe_update_active_network_details(&new_network) {
+        if !update_active_network(&self.network_tx, &new_network) {
             tracing::debug!("Network environment unchanged, skipping cache refresh");
             return;
         }
 
         tracing::info!("Network environment updated");
-        let _ = self.network_tx.send_replace(new_network.clone());
 
         // Update gateway cache and topology cache for new environment
         crate::cache_refresh::update_caches_for_network(
@@ -1029,25 +1028,6 @@ impl NymVpnService {
             &self.user_agent,
         )
         .await;
-    }
-
-    /// Updates the currently active network environment if `new_network` differs from it.
-    /// Returns whether an update was applied.
-    fn maybe_update_active_network_details(&mut self, new_network: &Network) -> bool {
-        if self.network_tx.borrow().as_ref() == new_network {
-            return false;
-        }
-
-        let addrs = new_network
-            .dns_fallback_addr_map()
-            .into_iter()
-            .map(|(host, addrs)| (host, addrs.into_iter().collect()))
-            .collect();
-
-        HickoryDnsResolver::shared().set_fallback_addrs(addrs);
-
-        let _ = self.network_tx.send_replace(Box::new(new_network.clone()));
-        true
     }
 
     // Wrap handle_service_command in timing code to log long-running commands
@@ -2522,5 +2502,127 @@ impl NymVpnService {
     async fn handle_set_profile(&mut self, profile: Profile) {
         self.config_manager.set_profile(profile).await;
         self.update_tunnel_settings_with_throttle();
+    }
+}
+
+/// Updates `network_tx` with `new_network` if it differs from the currently active network,
+/// applying the DNS fallback update as a side effect. Publishes the new value through
+/// `send_replace` exactly once. Returns whether an update was applied.
+fn update_active_network(network_tx: &watch::Sender<Box<Network>>, new_network: &Network) -> bool {
+    if network_tx.borrow().as_ref() == new_network {
+        return false;
+    }
+
+    let addrs = new_network
+        .dns_fallback_addr_map()
+        .into_iter()
+        .map(|(host, addrs)| (host, addrs.into_iter().collect()))
+        .collect();
+
+    HickoryDnsResolver::shared().set_fallback_addrs(addrs);
+
+    let _ = network_tx.send_replace(Box::new(new_network.clone()));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn distinct_networks() -> (Network, Network) {
+        let a = Network::mainnet_default().expect("bundled mainnet network");
+        let mut b = a.clone();
+        b.nyxd_url = "https://example.com".parse().expect("valid url");
+        assert_ne!(a, b, "test networks must be distinct");
+        (a, b)
+    }
+
+    /// Counts every distinct `changed()` notification observed on `network_rx`, giving the
+    /// scheduler a real gap (via `sleep`) between publishes so that back-to-back sends are not
+    /// coalesced into a single wakeup, the way `Receiver::has_changed()` would if checked
+    /// synchronously. This mirrors the production risk: two independent call sites publishing
+    /// the same network state can each wake a subscriber separately.
+    async fn count_notifications(
+        mut network_rx: watch::Receiver<Box<Network>>,
+    ) -> Arc<AtomicUsize> {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_clone = count.clone();
+        tokio::spawn(async move {
+            while network_rx.changed().await.is_ok() {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        // Let the watcher task start and register its waker before the caller publishes.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        count
+    }
+
+    /// Regression test: a single logical network change must publish exactly one update on
+    /// `network_tx`. Before this fix, `handle_network_change` called
+    /// `maybe_update_active_network_details` (which itself published via `send_replace`) and
+    /// then published the *same* state again itself, so a subscriber could observe two separate
+    /// notifications for one change. `update_active_network` is now the only place that
+    /// publishes, so exactly one notification is delivered.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn network_change_publishes_update_exactly_once() {
+        let (network_a, network_b) = distinct_networks();
+        let (network_tx, network_rx) = watch::channel(Box::new(network_a));
+        let count = count_notifications(network_rx).await;
+
+        let updated = update_active_network(&network_tx, &network_b);
+        assert!(updated, "differing network should be applied");
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "subscriber should observe exactly one notification for one network change"
+        );
+        assert_eq!(network_tx.borrow().as_ref(), &network_b);
+    }
+
+    /// Guards against the exact regression this test suite is named for: if a second call site
+    /// were to independently `send_replace` the same state that `update_active_network` already
+    /// published (as `handle_network_change` used to do), the subscriber would see two
+    /// notifications instead of one. This test exercises that duplicated-publish shape directly
+    /// so it fails if the duplication ever comes back.
+    #[tokio::test]
+    async fn duplicate_publish_of_same_state_is_detected_as_two_notifications() {
+        let (network_a, network_b) = distinct_networks();
+        let (network_tx, network_rx) = watch::channel(Box::new(network_a));
+        let count = count_notifications(network_rx).await;
+
+        assert!(update_active_network(&network_tx, &network_b));
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Simulates a second, independent call site re-publishing the same state that
+        // `update_active_network` already sent (the bug this fix removes).
+        let _ = network_tx.send_replace(Box::new(network_b.clone()));
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            2,
+            "two independent publishes of the same state must show up as two notifications, \
+             proving the earlier test would fail if the duplicate publish returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_network_does_not_publish() {
+        let (network_a, _) = distinct_networks();
+        let (network_tx, network_rx) = watch::channel(Box::new(network_a.clone()));
+        let count = count_notifications(network_rx).await;
+
+        let updated = update_active_network(&network_tx, &network_a);
+
+        assert!(!updated, "identical network should not be applied");
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "receiver should not observe a change when network is unchanged"
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -668,7 +668,7 @@ impl TunnelMonitor {
             .custom_topology_provider(Box::new(
                 self.custom_topology_provider.make_topology_provider(),
             ))
-            .network_env(nym_network)
+            .network_env(nym_network.into())
             .cancel_token(self.shutdown_token.child_token());
 
         #[cfg(unix)]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
@@ -4,7 +4,8 @@
 use std::time::Duration;
 
 use nym_http_api_client::Client as HttpApiClient;
-use nym_sdk::{NymNetworkDetails, UserAgent};
+use nym_sdk::UserAgent;
+use nym_network_defaults::v2::NymNetworkDetails;
 use nym_validator_client::nym_api::NymApiClientExt;
 use nym_vpn_api_client::{VpnApiClient, api_urls_to_urls, fronted_http_client};
 
@@ -70,7 +71,7 @@ impl Fetcher {
     /// Fetch network details from the API.
     pub async fn fetch_network_details(&self) -> Result<Box<NymNetworkDetails>> {
         self.api_client
-            .get_network_details()
+            .get_network_details_v2()
             .await
             .map(|response| response.network)
             .map(Box::new)

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
@@ -4,8 +4,8 @@
 use std::time::Duration;
 
 use nym_http_api_client::Client as HttpApiClient;
-use nym_sdk::UserAgent;
 use nym_network_defaults::v2::NymNetworkDetails;
+use nym_sdk::UserAgent;
 use nym_validator_client::nym_api::NymApiClientExt;
 use nym_vpn_api_client::{VpnApiClient, api_urls_to_urls, fronted_http_client};
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -17,9 +17,9 @@ mod serialization;
 mod system_configuration;
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt::Debug,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
@@ -41,6 +41,7 @@ pub use system_messages::{SystemMessage, SystemMessages};
 
 use nym_common::trace_err_chain;
 use nym_http_api_client::HttpClientError;
+use nym_network_defaults::v2::DnsFallback;
 use nym_sdk::{UserAgent, mixnet::Recipient};
 use nym_vpn_api_client::str_to_socket_addr;
 
@@ -65,6 +66,35 @@ pub struct Network {
     pub nym_vpn_network: NymVpnNetwork,
     pub feature_flags: Option<FeatureFlags>,
     pub system_configuration: Option<SystemConfiguration>,
+    dns_fallbacks: HashMap<String, HashSet<IpAddr>>,
+}
+
+fn dns_fallback_addr_map(fallbacks: &[DnsFallback]) -> HashMap<String, HashSet<IpAddr>> {
+    fallbacks
+        .iter()
+        .filter_map(|fallback| {
+            let addrs: HashSet<IpAddr> = fallback
+                .addresses
+                .iter()
+                .filter_map(|addr| {
+                    addr.parse()
+                        .inspect_err(|err| {
+                            tracing::warn!(
+                                "Invalid dns fallback address '{addr}' for '{}': {err}",
+                                fallback.url
+                            );
+                        })
+                        .ok()
+                })
+                .collect();
+
+            if addrs.is_empty() {
+                None
+            } else {
+                Some((fallback.url.clone(), addrs))
+            }
+        })
+        .collect()
 }
 
 impl Network {
@@ -91,6 +121,7 @@ impl Network {
 
         let feature_flags = discovery.feature_flags.clone();
         let system_configuration = discovery.system_configuration.clone();
+        let dns_fallbacks = dns_fallback_addr_map(&network_details.networking.dns_fallbacks);
         let endpoint = network_details
             .endpoints
             .first()
@@ -104,7 +135,14 @@ impl Network {
             nym_vpn_network,
             feature_flags,
             system_configuration,
+            dns_fallbacks,
         })
+    }
+
+    /// Map of hostname to fallback IP addresses to use for DNS resolution when the primary
+    /// resolver fails, as configured by discovery.
+    pub fn dns_fallback_addr_map(&self) -> HashMap<String, HashSet<IpAddr>> {
+        self.dns_fallbacks.clone()
     }
 
     pub fn nym_network_details(&self) -> &NymNetworkDetails {
@@ -288,7 +326,7 @@ impl NetworkCache {
             Some(ref mut details) => {
                 if details.is_stale() {
                     let new_network_details = self.fetcher.fetch_network_details().await?;
-                    details.update((*new_network_details).into()).await?;
+                    details.update(*new_network_details).await?;
                 }
             }
             ref mut details @ None => {
@@ -296,7 +334,7 @@ impl NetworkCache {
                 let new_persistent_network_details =
                     PersistentNetworkDetails::new_with_newly_fetched(
                         self.cache_dir.clone(),
-                        (*new_network_details).into(),
+                        *new_network_details,
                     )
                     .await?;
                 details.replace(new_persistent_network_details);
@@ -549,5 +587,17 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_mainnet_default_network_has_dns_fallback_addrs() {
+        let network = Network::mainnet_default().unwrap();
+        let fallbacks = network.dns_fallback_addr_map();
+
+        assert!(!fallbacks.is_empty());
+        for (host, addrs) in &fallbacks {
+            assert!(!host.is_empty());
+            assert!(!addrs.is_empty());
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -34,7 +34,7 @@ pub use discovery_refresher::{DiscoveryRefresher, DiscoveryRefresherCommand};
 pub use envs::RegisteredNetworks;
 pub use feature_flags::{FeatureFlags, FlagValue};
 pub use fetcher::Fetcher;
-pub use nym_network_defaults::NymNetworkDetails;
+pub use nym_network_defaults::v2::NymNetworkDetails;
 pub use nym_vpn_network::NymVpnNetwork;
 pub use system_configuration::{ScoreThresholds, SystemConfiguration};
 pub use system_messages::{SystemMessage, SystemMessages};
@@ -112,7 +112,7 @@ impl Network {
     }
 
     pub fn export_to_env(&self) {
-        self.nym_network.clone().export_to_env();
+        nym_network_defaults::NymNetworkDetails::from(self.nym_network.clone()).export_to_env();
         self.nym_vpn_network.export_to_env();
     }
 
@@ -121,11 +121,12 @@ impl Network {
     }
 
     pub fn nym_api_urls(&self) -> Option<Vec<nym_network_defaults::ApiUrl>> {
-        self.nym_network.nym_api_urls.clone()
+        let urls = self.nym_network.nym_api_urls();
+        (!urls.is_empty()).then_some(urls)
     }
 
     pub fn nym_api_urls_as_urls(&self) -> Option<Vec<url::Url>> {
-        self.nym_network.nym_api_urls.as_ref().map(|urls| {
+        self.nym_api_urls().map(|urls| {
             urls.iter()
                 .filter_map(|api_url| url::Url::parse(&api_url.url).ok())
                 .collect()
@@ -133,11 +134,12 @@ impl Network {
     }
 
     pub fn nym_vpn_api_urls(&self) -> Option<Vec<nym_network_defaults::ApiUrl>> {
-        self.nym_network.nym_vpn_api_urls.clone()
+        let urls = self.nym_network.nym_vpn_api_urls();
+        (!urls.is_empty()).then_some(urls)
     }
 
     pub fn nym_vpn_api_urls_as_urls(&self) -> Option<Vec<url::Url>> {
-        self.nym_network.nym_vpn_api_urls.as_ref().map(|urls| {
+        self.nym_vpn_api_urls().map(|urls| {
             urls.iter()
                 .filter_map(|api_url| url::Url::parse(&api_url.url).ok())
                 .collect()
@@ -286,7 +288,7 @@ impl NetworkCache {
             Some(ref mut details) => {
                 if details.is_stale() {
                     let new_network_details = self.fetcher.fetch_network_details().await?;
-                    details.update(*new_network_details).await?;
+                    details.update((*new_network_details).into()).await?;
                 }
             }
             ref mut details @ None => {
@@ -294,7 +296,7 @@ impl NetworkCache {
                 let new_persistent_network_details =
                     PersistentNetworkDetails::new_with_newly_fetched(
                         self.cache_dir.clone(),
-                        *new_network_details,
+                        (*new_network_details).into(),
                     )
                     .await?;
                 details.replace(new_persistent_network_details);
@@ -331,16 +333,11 @@ impl NetworkCache {
         network_details: &mut NymNetworkDetails,
         discovery: &Discovery,
     ) {
-        if network_details.nym_vpn_api_urls.is_none()
-            || network_details
-                .nym_vpn_api_urls
-                .as_ref()
-                .is_some_and(|v| v.is_empty())
-        {
+        if network_details.nym_vpn_api_urls().is_empty() {
             tracing::debug!(
                 "Patching up network details from discovery due to missing network details!"
             );
-            network_details.nym_vpn_api_urls = Some(discovery.nym_vpn_api_urls());
+            network_details.networking.nym_vpn_api_urls = discovery.nym_vpn_api_urls();
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -588,16 +588,4 @@ mod tests {
                 .unwrap()
         );
     }
-
-    #[test]
-    fn test_mainnet_default_network_has_dns_fallback_addrs() {
-        let network = Network::mainnet_default().unwrap();
-        let fallbacks = network.dns_fallback_addr_map();
-
-        assert!(!fallbacks.is_empty());
-        for (host, addrs) in &fallbacks {
-            assert!(!host.is_empty());
-            assert!(!addrs.is_empty());
-        }
-    }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
@@ -113,11 +113,9 @@ impl PersistentNetworkDetails {
         path: &Path,
         network_name: &str,
     ) -> Option<Self> {
-        let legacy = crate::serialization::deserialize_from_json_file::<
-            _,
-            LegacyCachedNetworkDetails,
-        >(path)
-        .ok()?;
+        let legacy =
+            crate::serialization::deserialize_from_json_file::<_, LegacyCachedNetworkDetails>(path)
+                .ok()?;
 
         if legacy.value.network_name != network_name {
             return None;

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
@@ -4,11 +4,15 @@
 use std::path::{Path, PathBuf};
 
 use nym_common::trace_err_chain;
-use nym_sdk::NymNetworkDetails;
+use nym_network_defaults::v2::NymNetworkDetails;
 
 use crate::{Error, PersistentRecord, Result};
 
 type CachedNetworkDetails = PersistentRecord<NymNetworkDetails>;
+
+/// Pre-v2 on-disk shape, kept around solely to migrate caches written by older clients.
+/// See [`PersistentNetworkDetails::try_migrate_legacy`].
+type LegacyCachedNetworkDetails = PersistentRecord<nym_network_defaults::NymNetworkDetails>;
 
 /// Persistent network details store that keeps track of last modification date
 #[derive(Debug)]
@@ -63,6 +67,11 @@ impl PersistentNetworkDetails {
             }
             Err(err) if err.should_overwrite_file() => {
                 if !err.is_file_not_found() {
+                    if let Some(migrated) =
+                        Self::try_migrate_legacy(cache_dir.clone(), &path, network_name).await
+                    {
+                        return Ok(migrated);
+                    }
                     trace_err_chain!(err, "failed to deserialize cache");
                 }
                 if network_name == "mainnet" {
@@ -90,6 +99,44 @@ impl PersistentNetworkDetails {
     /// Returns network name referenced by discovery
     pub fn network_name(&self) -> &str {
         &self.cached_network_details.value.network_name
+    }
+
+    /// Attempts to read `path` as a pre-v2 [`nym_network_defaults::NymNetworkDetails`] record
+    /// and, if it parses and its network name matches, converts it into the current shape and
+    /// rewrites the file in place. This lets clients upgrading across the v1 -> v2 on-disk
+    /// format keep their existing cache (e.g. discovery-fetched overrides) instead of it being
+    /// treated as corrupt and discarded. Returns `None` if the file doesn't parse as the legacy
+    /// shape either, or its network name doesn't match, leaving the caller to fall back to its
+    /// usual "no usable cache" handling.
+    async fn try_migrate_legacy(
+        cache_dir: PathBuf,
+        path: &Path,
+        network_name: &str,
+    ) -> Option<Self> {
+        let legacy = crate::serialization::deserialize_from_json_file::<
+            _,
+            LegacyCachedNetworkDetails,
+        >(path)
+        .ok()?;
+
+        if legacy.value.network_name != network_name {
+            return None;
+        }
+
+        let migrated = Self {
+            cache_dir,
+            cached_network_details: PersistentRecord {
+                updated_at: legacy.updated_at,
+                value: legacy.value.into(),
+            },
+        };
+
+        migrated.write().await.ok()?;
+        tracing::info!(
+            "Migrated cached network details for '{network_name}' to the current on-disk format"
+        );
+
+        Some(migrated)
     }
 
     /// Update network details and persist changes on disk.
@@ -220,6 +267,37 @@ mod tests {
                 .await
                 .is_err_and(|err| err.is_inconsistent_network())
         );
+    }
+
+    #[tokio::test]
+    async fn test_migrates_legacy_v1_cache_on_disk() {
+        let cache_dir = tempdir().unwrap();
+        let path = PersistentNetworkDetails::path(cache_dir.path(), "sandbox");
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+
+        let legacy_value = nym_network_defaults::sandbox::network_details();
+        let legacy_record = LegacyCachedNetworkDetails::up_to_date(legacy_value.clone());
+        crate::serialization::serialize_to_json_file(&path, &legacy_record).unwrap();
+
+        // Without the legacy fallback this would fail with `NoDefaultNetworkDetails`, since
+        // there's no bundled default for non-mainnet networks (see
+        // `test_should_fail_creating_empty_cache_for_non_mainnet`).
+        let migrated =
+            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
+                .await
+                .unwrap();
+        assert_eq!(migrated.value(), &NymNetworkDetails::from(legacy_value));
+        assert!(!migrated.is_stale());
+
+        // The file on disk should have been rewritten in the current shape, so a subsequent
+        // load doesn't need to migrate again.
+        let reloaded =
+            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
+                .await
+                .unwrap();
+        assert_eq!(reloaded.value(), migrated.value());
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
@@ -129,10 +129,16 @@ impl PersistentNetworkDetails {
             },
         };
 
-        migrated.write().await.ok()?;
-        tracing::info!(
-            "Migrated cached network details for '{network_name}' to the current on-disk format"
-        );
+        if let Err(err) = migrated.write().await {
+            trace_err_chain!(
+                err,
+                "Migrated cached network details for '{network_name}' in memory, but failed to persist the rewritten cache"
+            );
+        } else {
+            tracing::info!(
+                "Migrated cached network details for '{network_name}' to the current on-disk format"
+            );
+        }
 
         Some(migrated)
     }
@@ -296,6 +302,49 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(reloaded.value(), migrated.value());
+    }
+
+    /// Regression test: if migrating a legacy cache succeeds in memory but rewriting it to disk
+    /// fails (e.g. read-only filesystem), the migrated record must still be returned instead of
+    /// being silently discarded as `None`, which would otherwise make the caller fall back to
+    /// `NoDefaultNetworkDetails` for a network that has no bundled defaults.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_migration_kept_in_memory_when_persisting_rewritten_cache_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let cache_dir = tempdir().unwrap();
+        let path = PersistentNetworkDetails::path(cache_dir.path(), "sandbox");
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+
+        let legacy_value = nym_network_defaults::sandbox::network_details();
+        let legacy_record = LegacyCachedNetworkDetails::up_to_date(legacy_value.clone());
+        crate::serialization::serialize_to_json_file(&path, &legacy_record).unwrap();
+
+        // Make the cache file itself unwritable so the migration can still read the legacy
+        // record back, but rewriting it to disk in the current shape fails.
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o444);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        // Root ignores file permissions, which would make this test meaningless there; skip it
+        // in that case rather than asserting on a condition we can't actually induce.
+        let permission_enforced = std::fs::OpenOptions::new().write(true).open(&path).is_err();
+
+        if permission_enforced {
+            let migrated =
+                PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
+                    .await
+                    .unwrap();
+            assert_eq!(migrated.value(), &NymNetworkDetails::from(legacy_value));
+        }
+
+        // Restore write permission so the tempdir can clean itself up.
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&path, permissions).unwrap();
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
@@ -10,10 +10,6 @@ use crate::{Error, PersistentRecord, Result};
 
 type CachedNetworkDetails = PersistentRecord<NymNetworkDetails>;
 
-/// Pre-v2 on-disk shape, kept around solely to migrate caches written by older clients.
-/// See [`PersistentNetworkDetails::try_migrate_legacy`].
-type LegacyCachedNetworkDetails = PersistentRecord<nym_network_defaults::NymNetworkDetails>;
-
 /// Persistent network details store that keeps track of last modification date
 #[derive(Debug)]
 pub struct PersistentNetworkDetails {
@@ -67,11 +63,6 @@ impl PersistentNetworkDetails {
             }
             Err(err) if err.should_overwrite_file() => {
                 if !err.is_file_not_found() {
-                    if let Some(migrated) =
-                        Self::try_migrate_legacy(cache_dir.clone(), &path, network_name).await
-                    {
-                        return Ok(migrated);
-                    }
                     trace_err_chain!(err, "failed to deserialize cache");
                 }
                 if network_name == "mainnet" {
@@ -99,48 +90,6 @@ impl PersistentNetworkDetails {
     /// Returns network name referenced by discovery
     pub fn network_name(&self) -> &str {
         &self.cached_network_details.value.network_name
-    }
-
-    /// Attempts to read `path` as a pre-v2 [`nym_network_defaults::NymNetworkDetails`] record
-    /// and, if it parses and its network name matches, converts it into the current shape and
-    /// rewrites the file in place. This lets clients upgrading across the v1 -> v2 on-disk
-    /// format keep their existing cache (e.g. discovery-fetched overrides) instead of it being
-    /// treated as corrupt and discarded. Returns `None` if the file doesn't parse as the legacy
-    /// shape either, or its network name doesn't match, leaving the caller to fall back to its
-    /// usual "no usable cache" handling.
-    async fn try_migrate_legacy(
-        cache_dir: PathBuf,
-        path: &Path,
-        network_name: &str,
-    ) -> Option<Self> {
-        let legacy =
-            crate::serialization::deserialize_from_json_file::<_, LegacyCachedNetworkDetails>(path)
-                .ok()?;
-
-        if legacy.value.network_name != network_name {
-            return None;
-        }
-
-        let migrated = Self {
-            cache_dir,
-            cached_network_details: PersistentRecord {
-                updated_at: legacy.updated_at,
-                value: legacy.value.into(),
-            },
-        };
-
-        if let Err(err) = migrated.write().await {
-            trace_err_chain!(
-                err,
-                "Migrated cached network details for '{network_name}' in memory, but failed to persist the rewritten cache"
-            );
-        } else {
-            tracing::info!(
-                "Migrated cached network details for '{network_name}' to the current on-disk format"
-            );
-        }
-
-        Some(migrated)
     }
 
     /// Update network details and persist changes on disk.
@@ -273,78 +222,44 @@ mod tests {
         );
     }
 
+    /// A cache file that doesn't parse as the current on-disk shape (e.g. one written by an
+    /// older client in a since-removed format) is treated the same as any other corrupt or
+    /// missing cache: for mainnet, fall back to the bundled default; for other networks, there's
+    /// nothing to fall back to on disk, so the caller must fetch from the network instead.
     #[tokio::test]
-    async fn test_migrates_legacy_v1_cache_on_disk() {
+    async fn test_unparsable_cache_falls_back_to_default_for_mainnet() {
         let cache_dir = tempdir().unwrap();
-        let path = PersistentNetworkDetails::path(cache_dir.path(), "sandbox");
+        let path = PersistentNetworkDetails::path(cache_dir.path(), "mainnet");
         tokio::fs::create_dir_all(path.parent().unwrap())
             .await
             .unwrap();
+        tokio::fs::write(&path, b"not a valid cache record")
+            .await
+            .unwrap();
 
-        let legacy_value = nym_network_defaults::sandbox::network_details();
-        let legacy_record = LegacyCachedNetworkDetails::up_to_date(legacy_value.clone());
-        crate::serialization::serialize_to_json_file(&path, &legacy_record).unwrap();
-
-        // Without the legacy fallback this would fail with `NoDefaultNetworkDetails`, since
-        // there's no bundled default for non-mainnet networks (see
-        // `test_should_fail_creating_empty_cache_for_non_mainnet`).
-        let migrated =
-            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
+        let persistent_network_details =
+            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "mainnet")
                 .await
                 .unwrap();
-        assert_eq!(migrated.value(), &NymNetworkDetails::from(legacy_value));
-        assert!(!migrated.is_stale());
-
-        // The file on disk should have been rewritten in the current shape, so a subsequent
-        // load doesn't need to migrate again.
-        let reloaded =
-            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
-                .await
-                .unwrap();
-        assert_eq!(reloaded.value(), migrated.value());
+        assert_eq!(persistent_network_details.value().network_name, "mainnet");
     }
 
-    /// Regression test: if migrating a legacy cache succeeds in memory but rewriting it to disk
-    /// fails (e.g. read-only filesystem), the migrated record must still be returned instead of
-    /// being silently discarded as `None`, which would otherwise make the caller fall back to
-    /// `NoDefaultNetworkDetails` for a network that has no bundled defaults.
     #[tokio::test]
-    #[cfg(unix)]
-    async fn test_migration_kept_in_memory_when_persisting_rewritten_cache_fails() {
-        use std::os::unix::fs::PermissionsExt;
-
+    async fn test_unparsable_cache_errors_for_non_mainnet() {
         let cache_dir = tempdir().unwrap();
         let path = PersistentNetworkDetails::path(cache_dir.path(), "sandbox");
         tokio::fs::create_dir_all(path.parent().unwrap())
             .await
             .unwrap();
+        tokio::fs::write(&path, b"not a valid cache record")
+            .await
+            .unwrap();
 
-        let legacy_value = nym_network_defaults::sandbox::network_details();
-        let legacy_record = LegacyCachedNetworkDetails::up_to_date(legacy_value.clone());
-        crate::serialization::serialize_to_json_file(&path, &legacy_record).unwrap();
-
-        // Make the cache file itself unwritable so the migration can still read the legacy
-        // record back, but rewriting it to disk in the current shape fails.
-        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
-        permissions.set_mode(0o444);
-        std::fs::set_permissions(&path, permissions).unwrap();
-
-        // Root ignores file permissions, which would make this test meaningless there; skip it
-        // in that case rather than asserting on a condition we can't actually induce.
-        let permission_enforced = std::fs::OpenOptions::new().write(true).open(&path).is_err();
-
-        if permission_enforced {
-            let migrated =
-                PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
-                    .await
-                    .unwrap();
-            assert_eq!(migrated.value(), &NymNetworkDetails::from(legacy_value));
-        }
-
-        // Restore write permission so the tempdir can clean itself up.
-        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
-        permissions.set_mode(0o644);
-        std::fs::set_permissions(&path, permissions).unwrap();
+        assert!(
+            PersistentNetworkDetails::new_from_cache(cache_dir.path().to_path_buf(), "sandbox")
+                .await
+                .is_err_and(|err| err.is_no_default_network_details())
+        );
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -179,13 +179,23 @@ message NymContracts {
 }
 
 message NymNetworkDetails {
+  reserved 5, 6, 7; // formerly nym_vpn_api_url / nym_api_urls / nym_vpn_api_urls, now nested in `networking`
   string network_name = 1;
   ChainDetails chain_details = 2;
   repeated ValidatorDetails endpoints = 3;
   NymContracts contracts = 4;
-  optional string nym_vpn_api_url = 5;
-  repeated ApiUrl nym_api_urls = 6;
-  repeated ApiUrl nym_vpn_api_urls = 7;
+  NymNetworkingSpecifics networking = 8;
+}
+
+message NymNetworkingSpecifics {
+  repeated ApiUrl nym_api_urls = 1;
+  repeated ApiUrl nym_vpn_api_urls = 2;
+  repeated DnsFallback dns_fallbacks = 3;
+}
+
+message DnsFallback {
+  string url = 1;
+  repeated string addresses = 2;
 }
 
 message NymVpnNetworkDetails {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
@@ -83,15 +83,23 @@ impl TryFrom<proto::NymNetworkDetails> for nym_vpn_lib_types::NymNetworkDetails 
             .clone()
             .map(nym_vpn_lib_types::NymContracts::from)
             .ok_or_else(|| ConversionError::Generic("missing contracts".to_string()))?;
-        let nym_api_urls = details
+        let networking = details
+            .networking
+            .ok_or_else(|| ConversionError::Generic("missing networking specifics".to_string()))?;
+        let nym_api_urls = networking
             .nym_api_urls
             .into_iter()
             .map(nym_vpn_lib_types::ApiUrl::from)
             .collect();
-        let nym_vpn_api_urls = details
+        let nym_vpn_api_urls = networking
             .nym_vpn_api_urls
             .into_iter()
             .map(nym_vpn_lib_types::ApiUrl::from)
+            .collect();
+        let dns_fallbacks = networking
+            .dns_fallbacks
+            .into_iter()
+            .map(nym_vpn_lib_types::DnsFallback::from)
             .collect();
 
         Ok(Self {
@@ -102,9 +110,27 @@ impl TryFrom<proto::NymNetworkDetails> for nym_vpn_lib_types::NymNetworkDetails 
             networking: nym_vpn_lib_types::NymNetworkingSpecifics {
                 nym_api_urls,
                 nym_vpn_api_urls,
-                dns_fallbacks: Vec::new(),
+                dns_fallbacks,
             },
         })
+    }
+}
+
+impl From<proto::DnsFallback> for nym_vpn_lib_types::DnsFallback {
+    fn from(value: proto::DnsFallback) -> Self {
+        Self {
+            url: value.url,
+            addresses: value.addresses,
+        }
+    }
+}
+
+impl From<nym_vpn_lib_types::DnsFallback> for proto::DnsFallback {
+    fn from(value: nym_vpn_lib_types::DnsFallback) -> Self {
+        Self {
+            url: value.url,
+            addresses: value.addresses,
+        }
     }
 }
 
@@ -206,14 +232,7 @@ impl From<nym_vpn_lib_types::NymNetworkDetails> for proto::NymNetworkDetails {
             .into_iter()
             .map(proto::ValidatorDetails::from)
             .collect();
-        // `nym_vpn_api_url` (singular) no longer exists on the current in-process type,
-        // which only tracks the full url list; derive it the same way the underlying
-        // v2 -> v1 network-defaults conversion does, for wire compatibility.
-        let nym_vpn_api_url = nym_network
-            .networking
-            .nym_vpn_api_urls
-            .first()
-            .map(|url| url.url.clone());
+
         let nym_api_urls = nym_network
             .networking
             .nym_api_urls
@@ -226,15 +245,25 @@ impl From<nym_vpn_lib_types::NymNetworkDetails> for proto::NymNetworkDetails {
             .into_iter()
             .map(proto::ApiUrl::from)
             .collect();
+        let dns_fallbacks = nym_network
+            .networking
+            .dns_fallbacks
+            .into_iter()
+            .map(proto::DnsFallback::from)
+            .collect();
+
+        let networking = proto::NymNetworkingSpecifics {
+            nym_api_urls,
+            nym_vpn_api_urls,
+            dns_fallbacks,
+        };
 
         proto::NymNetworkDetails {
             network_name: nym_network.network_name,
             chain_details: Some(nym_network.chain_details.into()),
             endpoints,
             contracts: Some(nym_network.contracts.into()),
-            nym_vpn_api_url,
-            nym_api_urls,
-            nym_vpn_api_urls,
+            networking: Some(networking),
         }
     }
 }
@@ -323,5 +352,87 @@ impl From<nym_vpn_lib_types::FeatureFlags> for proto::GetFeatureFlagsResponse {
         }
 
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_network_details() -> nym_vpn_lib_types::NymNetworkDetails {
+        nym_vpn_lib_types::NymNetworkDetails {
+            network_name: "mainnet".to_string(),
+            chain_details: nym_vpn_lib_types::ChainDetails {
+                bech32_account_prefix: "n".to_string(),
+                mix_denom: nym_vpn_lib_types::DenomDetailsOwned {
+                    base: "unym".to_string(),
+                    display: "nym".to_string(),
+                    display_exponent: 6,
+                },
+                stake_denom: nym_vpn_lib_types::DenomDetailsOwned {
+                    base: "unyx".to_string(),
+                    display: "nyx".to_string(),
+                    display_exponent: 6,
+                },
+            },
+            endpoints: Vec::new(),
+            contracts: nym_vpn_lib_types::NymContracts {
+                mixnet_contract_address: None,
+                vesting_contract_address: None,
+                performance_contract_address: None,
+                ecash_contract_address: None,
+                group_contract_address: None,
+                multisig_contract_address: None,
+                coconut_dkg_contract_address: None,
+            },
+            networking: nym_vpn_lib_types::NymNetworkingSpecifics {
+                nym_api_urls: Vec::new(),
+                nym_vpn_api_urls: Vec::new(),
+                dns_fallbacks: vec![nym_vpn_lib_types::DnsFallback {
+                    url: "harbourmaster.example.com".to_string(),
+                    addresses: vec!["1.2.3.4".to_string(), "::1".to_string()],
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn dns_fallbacks_survive_proto_round_trip() {
+        let original = sample_network_details();
+        let via_proto = proto::NymNetworkDetails::from(original.clone());
+        let proto_networking = via_proto
+            .networking
+            .as_ref()
+            .expect("networking specifics should be set");
+
+        assert_eq!(
+            proto_networking.dns_fallbacks.len(),
+            1,
+            "dns fallback should be carried onto the proto message"
+        );
+        assert_eq!(
+            proto_networking.dns_fallbacks[0].url,
+            "harbourmaster.example.com"
+        );
+        assert_eq!(
+            proto_networking.dns_fallbacks[0].addresses,
+            vec!["1.2.3.4".to_string(), "::1".to_string()]
+        );
+
+        let round_tripped = nym_vpn_lib_types::NymNetworkDetails::try_from(via_proto)
+            .expect("valid round trip conversion");
+
+        assert_eq!(
+            round_tripped.networking.dns_fallbacks.len(),
+            original.networking.dns_fallbacks.len()
+        );
+        assert_eq!(
+            round_tripped.networking.dns_fallbacks[0].url,
+            original.networking.dns_fallbacks[0].url
+        );
+        assert_eq!(
+            round_tripped.networking.dns_fallbacks[0].addresses,
+            original.networking.dns_fallbacks[0].addresses
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
@@ -99,9 +99,11 @@ impl TryFrom<proto::NymNetworkDetails> for nym_vpn_lib_types::NymNetworkDetails 
             chain_details,
             endpoints,
             contracts,
-            nym_vpn_api_url: details.nym_vpn_api_url,
-            nym_api_urls: Some(nym_api_urls),
-            nym_vpn_api_urls: Some(nym_vpn_api_urls),
+            networking: nym_vpn_lib_types::NymNetworkingSpecifics {
+                nym_api_urls,
+                nym_vpn_api_urls,
+                dns_fallbacks: Vec::new(),
+            },
         })
     }
 }
@@ -204,15 +206,23 @@ impl From<nym_vpn_lib_types::NymNetworkDetails> for proto::NymNetworkDetails {
             .into_iter()
             .map(proto::ValidatorDetails::from)
             .collect();
+        // `nym_vpn_api_url` (singular) no longer exists on the current in-process type,
+        // which only tracks the full url list; derive it the same way the underlying
+        // v2 -> v1 network-defaults conversion does, for wire compatibility.
+        let nym_vpn_api_url = nym_network
+            .networking
+            .nym_vpn_api_urls
+            .first()
+            .map(|url| url.url.clone());
         let nym_api_urls = nym_network
+            .networking
             .nym_api_urls
-            .unwrap_or_default()
             .into_iter()
             .map(proto::ApiUrl::from)
             .collect();
         let nym_vpn_api_urls = nym_network
+            .networking
             .nym_vpn_api_urls
-            .unwrap_or_default()
             .into_iter()
             .map(proto::ApiUrl::from)
             .collect();
@@ -222,7 +232,7 @@ impl From<nym_vpn_lib_types::NymNetworkDetails> for proto::NymNetworkDetails {
             chain_details: Some(nym_network.chain_details.into()),
             endpoints,
             contracts: Some(nym_network.contracts.into()),
-            nym_vpn_api_url: nym_network.nym_vpn_api_url,
+            nym_vpn_api_url,
             nym_api_urls,
             nym_vpn_api_urls,
         }

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -440,8 +440,11 @@ impl Command {
                     .coconut_dkg_contract_address
             )
         );
-        if let Some(nym_api_urls) = service_info.nym_network.nym_api_urls {
-            println!("  nym_api_urls:");
+        {
+            let nym_api_urls = service_info.nym_network.networking.nym_api_urls;
+            if !nym_api_urls.is_empty() {
+                println!("  nym_api_urls:");
+            }
             for nym_api_url in nym_api_urls {
                 println!("    - url: {}", nym_api_url.url);
                 match nym_api_url.front_hosts {
@@ -456,18 +459,16 @@ impl Command {
             }
         }
         println!("  nym_vpn_api_urls:");
-        if let Some(nym_vpn_api_urls) = service_info.nym_network.nym_vpn_api_urls {
-            for nym_vpn_api_url in nym_vpn_api_urls {
-                println!("    - url: {}", nym_vpn_api_url.url);
-                match nym_vpn_api_url.front_hosts {
-                    Some(fronts) => {
-                        println!(
-                            "      fronts: {}",
-                            fronts.into_iter().collect::<Vec<String>>().join(", ")
-                        );
-                    }
-                    None => println!("      fronts: (unset)"),
+        for nym_vpn_api_url in service_info.nym_network.networking.nym_vpn_api_urls {
+            println!("    - url: {}", nym_vpn_api_url.url);
+            match nym_vpn_api_url.front_hosts {
+                Some(fronts) => {
+                    println!(
+                        "      fronts: {}",
+                        fronts.into_iter().collect::<Vec<String>>().join(", ")
+                    );
                 }
+                None => println!("      fronts: (unset)"),
             }
         }
 

--- a/nym-vpn-core/crates/test/test-manager/src/device_cleanup.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/device_cleanup.rs
@@ -15,7 +15,7 @@ use nym_vpn_api_client::{
 };
 
 pub async fn delete_all_devices(mnemonic: &str) -> Result<()> {
-    let network = nym_network_defaults::NymNetworkDetails::new_mainnet();
+    let network = nym_network_defaults::v2::NymNetworkDetails::new_mainnet();
     let client = VpnApiClient::from_network(&network, None)
         .await
         .context("Failed to create VPN API client")?;


### PR DESCRIPTION
## Description

Adapt to use the V2 version of the Network details from the Nym API. This adds end-to-end plumbing for DNS fallback addresses served by the Nym API network-details endpoint

* Makes use of the `v2/network/details` endpoint that has the updated format for the networking information including DNS fallback information. 
* Add `DnsFallback` support from the nym repos `nym-network-defaults` crate.
* Wire fallbacks into DNS resolution -- `Network::dns_fallback_addr_map()` feeds `HickoryDnsResolver::shared().set_fallback_addrs(...)`, applied both at `NymVpnService` startup (from persisted/default discovery) and whenever a live discovery refresh actually changes the active network.

This PR is a sibling to https://github.com/nymtech/nym-vpn-client/pull/6126 as this is intended to pull in any IP information shared over the Nym API and apply it to the DNS fallbacks used by the resolver. The two PRs will need to be integrated in the sense that they both use the same mechanism for tracking IPs received after a network details change. The details are TBD, but in general we need a policy for joining the fallbacks from discovery and network-details -- the simplest version is just to join them, though discovery is more configurable and therefor may be more reliable / specific. 

## Checklist:

- [x] wire configured dns fallback information into Network Details refresh 
- [x] successful connections verifying in debug logs that dns fallback addrs get updated. 
- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6279)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network configuration now supports multiple API endpoints and DNS fallback addresses.
  * VPN services apply DNS fallback settings when network conditions change.
  * Added support for migrating previously cached network configurations.

* **Bug Fixes**
  * Improved handling when VPN API endpoints are unavailable.
  * Prevented unnecessary refreshes when the network environment is unchanged.
  * Improved display of configured API endpoints in service information.
  * Preserved migrated network data when cache rewriting fails.
  * Preserved DNS fallback settings across service configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->