### PR TITLE
Fix/core dead entry fail fast

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
@@ -1,16 +1,18 @@
 use crate::NodeIdentity;
 use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fmt,
     hash::Hash,
-    sync::{Arc, RwLock},
-    time::{Duration, Instant},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, RwLock},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 /// Why a gateway was added to the blacklist, kept around so the selector can log a useful
 /// message when it later excludes that gateway, instead of just "it's blacklisted".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BlacklistReason {
     /// The WG handshake timed out, or a post-handshake connectivity probe failed, without a
     /// healthy metadata path ever being established through this gateway acting as exit.
@@ -23,6 +25,30 @@ pub enum BlacklistReason {
     /// The WG handshake with this entry gateway never completed: the entry hop is dead from
     /// the current network (e.g. its WG port is blackholed), regardless of the exit gateway.
     EntryHandshakeFailed,
+}
+
+impl BlacklistReason {
+    /// How long a gateway stays excluded for this reason.
+    const TRANSIENT_TTL: Duration = Duration::from_mins(20);
+    const PERSISTENT_TTL: Duration = Duration::from_hours(24);
+
+    /// Whether the exclusion is worth keeping across restarts. Entry-side verdicts describe
+    /// the path between this network and the gateway, which does not heal by restarting the
+    /// app, so they are persisted; exit/registration failures are transient and stay in memory.
+    pub fn is_persistent(&self) -> bool {
+        match self {
+            Self::EntryHandshakeFailed | Self::EntryBlamedForRepeatedFailures => true,
+            Self::ConnectionFailed | Self::RegistrationFailed => false,
+        }
+    }
+
+    pub fn ttl(&self) -> Duration {
+        if self.is_persistent() {
+            Self::PERSISTENT_TTL
+        } else {
+            Self::TRANSIENT_TTL
+        }
+    }
 }
 
 impl fmt::Display for BlacklistReason {
@@ -40,58 +66,228 @@ impl fmt::Display for BlacklistReason {
 
 #[derive(Debug, Clone, Copy)]
 struct Entry {
-    expiry: Instant,
+    expires_at: SystemTime,
     reason: BlacklistReason,
 }
 
+impl Entry {
+    fn is_live(&self, now: SystemTime) -> bool {
+        self.expires_at > now
+    }
+}
+
+/// On-disk form of a persisted blacklist entry.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedEntry {
+    expires_at_unix_secs: u64,
+    reason: BlacklistReason,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    map: HashMap<NodeIdentity, Entry>,
+    /// When set, persistent entries are mirrored to this file after every change.
+    path: Option<PathBuf>,
+    /// Bumped on every change so that out-of-order writers never clobber a newer snapshot.
+    generation: u64,
+}
+
+/// What a change wants written to disk, captured while holding the state lock so that the
+/// actual file IO can happen after the lock is released.
+struct Snapshot {
+    path: PathBuf,
+    generation: u64,
+    persisted: HashMap<String, PersistedEntry>,
+}
+
+/// Serialises writers and remembers the newest generation on disk.
+#[derive(Debug, Default)]
+struct Persister {
+    last_written_generation: u64,
+}
+
+impl Persister {
+    /// Write `snapshot` unless a newer one has already been written. Failures are logged,
+    /// never propagated: a gateway must still get blacklisted in memory when the disk is
+    /// unavailable.
+    fn persist(&mut self, snapshot: Snapshot) {
+        if snapshot.generation <= self.last_written_generation {
+            return;
+        }
+        match write_atomically(&snapshot.path, &snapshot.persisted) {
+            Ok(()) => self.last_written_generation = snapshot.generation,
+            Err(err) => tracing::warn!(
+                "Failed to persist blacklisted gateways to {}: {err}",
+                snapshot.path.display()
+            ),
+        }
+    }
+}
+
+impl Inner {
+    fn prune(&mut self, now: SystemTime) {
+        self.map.retain(|_, entry| entry.is_live(now));
+    }
+
+    /// Capture the live persistent entries for writing once the lock is released. Returns
+    /// `None` for an in-memory only blacklist.
+    fn snapshot(&mut self, now: SystemTime) -> Option<Snapshot> {
+        let path = self.path.clone()?;
+        self.generation += 1;
+        let persisted: HashMap<String, PersistedEntry> = self
+            .map
+            .iter()
+            .filter(|(_, entry)| entry.reason.is_persistent() && entry.is_live(now))
+            .map(|(identity, entry)| {
+                let expires_at_unix_secs = entry
+                    .expires_at
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                (
+                    identity.to_base58_string(),
+                    PersistedEntry {
+                        expires_at_unix_secs,
+                        reason: entry.reason,
+                    },
+                )
+            })
+            .collect();
+        Some(Snapshot {
+            path,
+            generation: self.generation,
+            persisted,
+        })
+    }
+}
+
+fn write_atomically(path: &Path, persisted: &HashMap<String, PersistedEntry>) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(persisted)?;
+    std::fs::write(&tmp_path, json)?;
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn load_persisted(path: &Path, now: SystemTime) -> HashMap<NodeIdentity, Entry> {
+    let contents = match std::fs::read(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+        Err(err) => {
+            tracing::warn!(
+                "Failed to read blacklisted gateways from {}: {err}",
+                path.display()
+            );
+            return HashMap::new();
+        }
+    };
+    let persisted: HashMap<String, PersistedEntry> = match serde_json::from_slice(&contents) {
+        Ok(persisted) => persisted,
+        Err(err) => {
+            tracing::warn!(
+                "Ignoring corrupt blacklisted gateways file {}: {err}",
+                path.display()
+            );
+            return HashMap::new();
+        }
+    };
+    persisted
+        .into_iter()
+        .filter_map(|(identity, entry)| {
+            let identity = NodeIdentity::from_base58_string(&identity).ok()?;
+            // A corrupt or hand-edited value can exceed what `SystemTime` represents; drop
+            // the entry rather than panic at startup.
+            let expires_at =
+                UNIX_EPOCH.checked_add(Duration::from_secs(entry.expires_at_unix_secs))?;
+            let entry = Entry {
+                expires_at,
+                reason: entry.reason,
+            };
+            entry.is_live(now).then_some((identity, entry))
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Default)]
-pub struct BlacklistedGateways(Arc<RwLock<HashMap<NodeIdentity, Entry>>>);
+pub struct BlacklistedGateways(Arc<RwLock<Inner>>, Arc<Mutex<Persister>>);
 
 impl BlacklistedGateways {
-    const TTL: Duration = Duration::from_mins(20);
-
+    /// In-memory only blacklist; nothing survives a restart.
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn add(&self, identity: NodeIdentity, reason: BlacklistReason) -> Result<()> {
-        match self.0.write() {
-            Ok(mut map) => {
-                let now = Instant::now();
-                map.insert(
-                    identity,
-                    Entry {
-                        expiry: now + Self::TTL,
-                        reason,
-                    },
-                );
-                map.retain(|_, entry| entry.expiry >= now); // Housekeeping
-                Ok(())
-            }
-            Err(e) => Err(anyhow!("Failed to acquire write lock: {e}")),
+    /// Blacklist backed by `path` (when given): persistent entries recorded there by a previous
+    /// run are loaded, minus the expired ones, and every later change is mirrored back. A
+    /// missing or unreadable file yields an empty blacklist.
+    pub fn load_or_new(path: Option<PathBuf>) -> Self {
+        let Some(path) = path else {
+            return Self::new();
+        };
+        let map = load_persisted(&path, SystemTime::now());
+        if !map.is_empty() {
+            tracing::info!(
+                "Loaded {} persisted blacklisted gateway(s) from {}",
+                map.len(),
+                path.display()
+            );
         }
+        Self(
+            Arc::new(RwLock::new(Inner {
+                map,
+                path: Some(path),
+                generation: 0,
+            })),
+            Arc::default(),
+        )
+    }
+
+    /// Apply `mutate` under the state lock, then mirror the result to disk (if this blacklist
+    /// is file-backed) with the lock already released, so readers are never blocked on IO.
+    /// The file write is synchronous; call from a blocking context when on an async runtime.
+    fn mutate_and_persist(&self, mutate: impl FnOnce(&mut Inner, SystemTime)) -> Result<()> {
+        let now = SystemTime::now();
+        let snapshot = match self.0.write() {
+            Ok(mut inner) => {
+                mutate(&mut inner, now);
+                inner.snapshot(now)
+            }
+            Err(e) => return Err(anyhow!("Failed to acquire write lock: {e}")),
+        };
+        if let Some(snapshot) = snapshot {
+            match self.1.lock() {
+                Ok(mut persister) => persister.persist(snapshot),
+                Err(e) => return Err(anyhow!("Failed to acquire persistence lock: {e}")),
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add(&self, identity: NodeIdentity, reason: BlacklistReason) -> Result<()> {
+        self.mutate_and_persist(|inner, now| {
+            inner.map.insert(
+                identity,
+                Entry {
+                    expires_at: now + reason.ttl(),
+                    reason,
+                },
+            );
+            inner.prune(now); // Housekeeping
+        })
     }
 
     pub fn remove(&self, identity: &NodeIdentity) -> Result<()> {
-        match self.0.write() {
-            Ok(mut map) => {
-                let now = Instant::now();
-                map.remove(identity);
-                map.retain(|_, entry| entry.expiry >= now); // Housekeeping
-                Ok(())
-            }
-            Err(e) => Err(anyhow!("Failed to acquire write lock: {e}")),
-        }
+        self.mutate_and_persist(|inner, now| {
+            inner.map.remove(identity);
+            inner.prune(now); // Housekeeping
+        })
     }
 
     pub fn clear(&self) -> Result<()> {
-        match self.0.write() {
-            Ok(mut map) => {
-                map.clear();
-                Ok(())
-            }
-            Err(e) => Err(anyhow!("Failed to acquire write lock: {e}")),
-        }
+        self.mutate_and_persist(|inner, _now| inner.map.clear())
     }
 
     pub fn exists(&self, identity: &NodeIdentity) -> Result<bool> {
@@ -102,17 +298,21 @@ impl BlacklistedGateways {
     /// added, or its entry has expired).
     pub fn reason(&self, identity: &NodeIdentity) -> Result<Option<BlacklistReason>> {
         match self.0.read() {
-            Ok(map) => Ok(map
-                .get(identity)
-                .filter(|entry| entry.expiry > Instant::now())
-                .map(|entry| entry.reason)),
+            Ok(inner) => {
+                let now = SystemTime::now();
+                Ok(inner
+                    .map
+                    .get(identity)
+                    .filter(|entry| entry.is_live(now))
+                    .map(|entry| entry.reason))
+            }
             Err(e) => Err(anyhow!("Failed to acquire read lock: {e}")),
         }
     }
 
     pub fn is_empty(&self) -> Result<bool> {
         match self.0.read() {
-            Ok(map) => Ok(map.is_empty()),
+            Ok(inner) => Ok(inner.map.is_empty()),
             Err(e) => Err(anyhow!("Failed to acquire read lock: {e}")),
         }
     }
@@ -224,11 +424,11 @@ mod tests {
         let identity = create_test_identity("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42");
 
         // Add an entry with an expired timestamp
-        if let Ok(mut map) = blacklist.0.write() {
-            map.insert(
+        if let Ok(mut inner) = blacklist.0.write() {
+            inner.map.insert(
                 identity,
                 Entry {
-                    expiry: Instant::now() - Duration::from_secs(1),
+                    expires_at: SystemTime::now() - Duration::from_secs(1),
                     reason: BlacklistReason::ConnectionFailed,
                 },
             );
@@ -246,11 +446,11 @@ mod tests {
         let id2 = create_test_identity("HiVGQq2riqPFoPyYRYCZq3zFmFk15gnJzH4s9mHEbgKH");
 
         // Add an expired entry manually
-        if let Ok(mut map) = blacklist.0.write() {
-            map.insert(
+        if let Ok(mut inner) = blacklist.0.write() {
+            inner.map.insert(
                 id1,
                 Entry {
-                    expiry: Instant::now() - Duration::from_secs(1),
+                    expires_at: SystemTime::now() - Duration::from_secs(1),
                     reason: BlacklistReason::ConnectionFailed,
                 },
             );
@@ -262,9 +462,9 @@ mod tests {
             .unwrap();
 
         // The expired entry should have been cleaned up
-        if let Ok(map) = blacklist.0.read() {
-            assert!(!map.contains_key(&id1));
-            assert!(map.contains_key(&id2));
+        if let Ok(inner) = blacklist.0.read() {
+            assert!(!inner.map.contains_key(&id1));
+            assert!(inner.map.contains_key(&id2));
         }
     }
 
@@ -275,11 +475,11 @@ mod tests {
         let id2 = create_test_identity("HiVGQq2riqPFoPyYRYCZq3zFmFk15gnJzH4s9mHEbgKH");
 
         // Add an expired entry manually
-        if let Ok(mut map) = blacklist.0.write() {
-            map.insert(
+        if let Ok(mut inner) = blacklist.0.write() {
+            inner.map.insert(
                 id1,
                 Entry {
-                    expiry: Instant::now() - Duration::from_secs(1),
+                    expires_at: SystemTime::now() - Duration::from_secs(1),
                     reason: BlacklistReason::ConnectionFailed,
                 },
             );
@@ -295,9 +495,9 @@ mod tests {
         blacklist.remove(&id2).unwrap();
 
         // Both entries should be gone (id1 expired, id2 removed)
-        if let Ok(map) = blacklist.0.read() {
-            assert!(!map.contains_key(&id1));
-            assert!(!map.contains_key(&id2));
+        if let Ok(inner) = blacklist.0.read() {
+            assert!(!inner.map.contains_key(&id1));
+            assert!(!inner.map.contains_key(&id2));
         } else {
             panic!("Failed to acquire read lock");
         }
@@ -368,5 +568,194 @@ mod tests {
             BlacklistReason::EntryHandshakeFailed.to_string(),
             "entry WireGuard handshake failed"
         );
+    }
+
+    const ID_A: &str = "24h2yanCFU5iy7xNQmW6RowFa6EzmAYQdM1bs8Y1X6iH";
+    const ID_B: &str = "26ZmTxTVBKHZg8MTKwypHkXZVJhDC7QHuv3BdsyRyTuk";
+    const ID_C: &str = "27GwHdmXLULVieyXmxZ6v9DHzRJtTEjfode1dzbptEAK";
+    const ID_D: &str = "28tXg9mEW4mifgU1TdetVVAN5PvmhtLpHzFRMfJBT6ND";
+
+    #[test]
+    fn entry_side_reasons_are_persisted_across_reload_but_transient_ones_are_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blacklist.json");
+
+        let blacklist = BlacklistedGateways::load_or_new(Some(path.clone()));
+        blacklist
+            .add(
+                create_test_identity(ID_A),
+                BlacklistReason::EntryHandshakeFailed,
+            )
+            .unwrap();
+        blacklist
+            .add(
+                create_test_identity(ID_B),
+                BlacklistReason::EntryBlamedForRepeatedFailures,
+            )
+            .unwrap();
+        blacklist
+            .add(
+                create_test_identity(ID_C),
+                BlacklistReason::ConnectionFailed,
+            )
+            .unwrap();
+        blacklist
+            .add(
+                create_test_identity(ID_D),
+                BlacklistReason::RegistrationFailed,
+            )
+            .unwrap();
+
+        let reloaded = BlacklistedGateways::load_or_new(Some(path));
+        assert_eq!(
+            reloaded.reason(&create_test_identity(ID_A)).unwrap(),
+            Some(BlacklistReason::EntryHandshakeFailed)
+        );
+        assert_eq!(
+            reloaded.reason(&create_test_identity(ID_B)).unwrap(),
+            Some(BlacklistReason::EntryBlamedForRepeatedFailures)
+        );
+        assert!(
+            !reloaded.exists(&create_test_identity(ID_C)).unwrap(),
+            "an exit connection failure is transient and must not survive a restart"
+        );
+        assert!(!reloaded.exists(&create_test_identity(ID_D)).unwrap());
+    }
+
+    #[test]
+    fn persistent_reasons_get_a_long_ttl_and_transient_ones_keep_the_short_one() {
+        for reason in [
+            BlacklistReason::EntryHandshakeFailed,
+            BlacklistReason::EntryBlamedForRepeatedFailures,
+        ] {
+            assert!(reason.is_persistent(), "{reason} should be persisted");
+            assert!(
+                reason.ttl() >= Duration::from_hours(12),
+                "{reason} ttl too short"
+            );
+        }
+        for reason in [
+            BlacklistReason::ConnectionFailed,
+            BlacklistReason::RegistrationFailed,
+        ] {
+            assert!(!reason.is_persistent(), "{reason} should stay in memory");
+            assert_eq!(reason.ttl(), Duration::from_mins(20));
+        }
+    }
+
+    #[test]
+    fn remove_and_clear_are_reflected_in_the_persisted_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blacklist.json");
+        let id_a = create_test_identity(ID_A);
+        let id_b = create_test_identity(ID_B);
+
+        let blacklist = BlacklistedGateways::load_or_new(Some(path.clone()));
+        blacklist
+            .add(id_a, BlacklistReason::EntryHandshakeFailed)
+            .unwrap();
+        blacklist
+            .add(id_b, BlacklistReason::EntryHandshakeFailed)
+            .unwrap();
+        blacklist.remove(&id_a).unwrap();
+
+        let reloaded = BlacklistedGateways::load_or_new(Some(path.clone()));
+        assert!(!reloaded.exists(&id_a).unwrap());
+        assert!(reloaded.exists(&id_b).unwrap());
+
+        reloaded.clear().unwrap();
+        let reloaded = BlacklistedGateways::load_or_new(Some(path));
+        assert!(reloaded.is_empty().unwrap());
+    }
+
+    #[test]
+    fn expired_persisted_entries_are_dropped_on_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blacklist.json");
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"{ID_A}":{{"expires_at_unix_secs":1,"reason":"EntryHandshakeFailed"}},
+                   "{ID_B}":{{"expires_at_unix_secs":4102444800,"reason":"EntryHandshakeFailed"}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let blacklist = BlacklistedGateways::load_or_new(Some(path));
+        assert!(!blacklist.exists(&create_test_identity(ID_A)).unwrap());
+        assert!(blacklist.exists(&create_test_identity(ID_B)).unwrap());
+    }
+
+    #[test]
+    fn corrupt_or_missing_file_falls_back_to_an_empty_blacklist() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = BlacklistedGateways::load_or_new(Some(dir.path().join("nope.json")));
+        assert!(missing.is_empty().unwrap());
+
+        let corrupt_path = dir.path().join("corrupt.json");
+        std::fs::write(&corrupt_path, "not json at all").unwrap();
+        let corrupt = BlacklistedGateways::load_or_new(Some(corrupt_path.clone()));
+        assert!(corrupt.is_empty().unwrap());
+
+        // and it recovers: the next persistent add rewrites the file
+        corrupt
+            .add(
+                create_test_identity(ID_A),
+                BlacklistReason::EntryHandshakeFailed,
+            )
+            .unwrap();
+        let reloaded = BlacklistedGateways::load_or_new(Some(corrupt_path));
+        assert!(reloaded.exists(&create_test_identity(ID_A)).unwrap());
+    }
+
+    #[test]
+    fn concurrent_persistent_adds_all_reach_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blacklist.json");
+        let blacklist = BlacklistedGateways::load_or_new(Some(path.clone()));
+
+        let handles: Vec<_> = [ID_A, ID_B, ID_C, ID_D]
+            .into_iter()
+            .map(|id| {
+                let blacklist = blacklist.clone();
+                thread::spawn(move || {
+                    blacklist
+                        .add(
+                            create_test_identity(id),
+                            BlacklistReason::EntryHandshakeFailed,
+                        )
+                        .unwrap()
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let reloaded = BlacklistedGateways::load_or_new(Some(path));
+        for id in [ID_A, ID_B, ID_C, ID_D] {
+            assert!(
+                reloaded.exists(&create_test_identity(id)).unwrap(),
+                "{id} was lost by a racing writer"
+            );
+        }
+    }
+
+    #[test]
+    fn unrepresentable_persisted_expiry_is_dropped_instead_of_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blacklist.json");
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"{ID_A}":{{"expires_at_unix_secs":18446744073709551615,"reason":"EntryHandshakeFailed"}},
+                   "{ID_B}":{{"expires_at_unix_secs":4102444800,"reason":"EntryHandshakeFailed"}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let blacklist = BlacklistedGateways::load_or_new(Some(path));
+        assert!(!blacklist.exists(&create_test_identity(ID_A)).unwrap());
+        assert!(blacklist.exists(&create_test_identity(ID_B)).unwrap());
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
@@ -20,6 +20,9 @@ pub enum BlacklistReason {
     EntryBlamedForRepeatedFailures,
     /// Registration with this gateway failed.
     RegistrationFailed,
+    /// The WG handshake with this entry gateway never completed: the entry hop is dead from
+    /// the current network (e.g. its WG port is blackholed), regardless of the exit gateway.
+    EntryHandshakeFailed,
 }
 
 impl fmt::Display for BlacklistReason {
@@ -30,6 +33,7 @@ impl fmt::Display for BlacklistReason {
                 write!(f, "blamed for repeated pre-handshake failures")
             }
             Self::RegistrationFailed => write!(f, "registration failed"),
+            Self::EntryHandshakeFailed => write!(f, "entry WireGuard handshake failed"),
         }
     }
 }
@@ -356,5 +360,13 @@ mod tests {
 
         // Original should see the removal
         assert!(!blacklist.exists(&identity).unwrap());
+    }
+
+    #[test]
+    fn entry_handshake_failed_reason_is_human_readable() {
+        assert_eq!(
+            BlacklistReason::EntryHandshakeFailed.to_string(),
+            "entry WireGuard handshake failed"
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -730,6 +730,12 @@ pub struct GatewayList {
     gateways: Vec<Gateway>,
 }
 
+/// How many of the best-ranked gateways an ordering-criteria selection (e.g. "closest to the
+/// user") picks from at random. Always taking the single best one sends every user in a region
+/// to the same node, so one gateway that is unreachable from that region breaks the first
+/// connect for all of them; spreading over a few also evens out load.
+pub const CLOSEST_GATEWAY_CANDIDATES: usize = 3;
+
 impl GatewayList {
     pub fn new(gw_type: Option<GatewayType>, gateways: Vec<Gateway>) -> Self {
         GatewayList { gw_type, gateways }
@@ -798,6 +804,24 @@ impl GatewayList {
         F: FnMut(&Gateway, &Gateway) -> Ordering,
     {
         self.filter(filters).into_iter().min_by(cmp)
+    }
+
+    /// Pick one of the `candidates` smallest gateways under `cmp`, uniformly at random.
+    pub fn filtered_random_among_min_by<F>(
+        &self,
+        filters: &GatewayFilters,
+        cmp: F,
+        candidates: usize,
+    ) -> Option<Gateway>
+    where
+        F: FnMut(&Gateway, &Gateway) -> Ordering,
+    {
+        let mut filtered = self.filter(filters);
+        filtered.sort_by(cmp);
+        filtered
+            .into_iter()
+            .take(candidates)
+            .choose(&mut rand::thread_rng())
     }
 
     pub fn retain_gateways_by<F>(&mut self, pred: F)
@@ -965,7 +989,11 @@ impl GatewayList {
 
             let filters = base_filters.with(&[GatewayFilter::MinScore(score)]);
 
-            if let Some(gateway) = self.filtered_min_by(&filters, &mut ordering_criteria) {
+            if let Some(gateway) = self.filtered_random_among_min_by(
+                &filters,
+                &mut ordering_criteria,
+                CLOSEST_GATEWAY_CANDIDATES,
+            ) {
                 return Ok(gateway);
             }
         }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -655,3 +655,99 @@ fn create_response_nym_gateway(
         family_data: None,
     }
 }
+
+fn gw_at_latitude(id: &str, latitude: f64, score: ScoreValue) -> Gateway {
+    Gateway::builder()
+        .identity(NodeIdentity::from_base58_string(id).unwrap())
+        .location(Location {
+            two_letter_iso_country_code: "XX".to_owned(),
+            latitude,
+            longitude: 0.0,
+            city: String::new(),
+            region: String::new(),
+            asn: None,
+        })
+        .performance(Performance {
+            last_updated_utc: String::new(),
+            score,
+            mixnet_score: score,
+            load: ScoreValue::Low,
+            uptime_percentage_last_24_hours: 1f32,
+        })
+        .build()
+}
+
+fn latitude_distance_to_equator(gw1: &Gateway, gw2: &Gateway) -> std::cmp::Ordering {
+    let lat = |gw: &Gateway| {
+        gw.location
+            .as_ref()
+            .map(|l| l.latitude.abs())
+            .unwrap_or(f64::MAX)
+    };
+    lat(gw1).total_cmp(&lat(gw2))
+}
+
+const CLOSEST_IDS: [&str; 6] = [
+    "24h2yanCFU5iy7xNQmW6RowFa6EzmAYQdM1bs8Y1X6iH",
+    "26ZmTxTVBKHZg8MTKwypHkXZVJhDC7QHuv3BdsyRyTuk",
+    "27GwHdmXLULVieyXmxZ6v9DHzRJtTEjfode1dzbptEAK",
+    "28tXg9mEW4mifgU1TdetVVAN5PvmhtLpHzFRMfJBT6ND",
+    "29U3LythwEaqigL5YajXALw1c7DE7YNcRW7Vn7KcYMQL",
+    "2aZj5UjC4N3SMjfJNjFiaHPqg1sgKDBYwaLozxGePQxW",
+];
+
+#[test]
+fn closest_pick_is_spread_over_the_nearest_candidates_only() {
+    // Gateways sit at increasing distance from the reference (the equator).
+    let gateways = CLOSEST_IDS
+        .iter()
+        .enumerate()
+        .map(|(i, id)| gw_at_latitude(id, i as f64 * 10.0, ScoreValue::High))
+        .collect();
+    let list = GatewayList::new(Some(GatewayType::Wg), gateways);
+
+    let mut picked = std::collections::HashSet::new();
+    for _ in 0..300 {
+        let gw = list
+            .find_best_ordering_criteria_gateway(
+                latitude_distance_to_equator,
+                &GatewayFilters::default(),
+            )
+            .unwrap();
+        picked.insert(gw.identity().to_base58_string());
+    }
+
+    let nearest: std::collections::HashSet<String> = CLOSEST_IDS[..CLOSEST_GATEWAY_CANDIDATES]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        picked.is_subset(&nearest),
+        "only the {CLOSEST_GATEWAY_CANDIDATES} nearest gateways may be picked, got {picked:?}"
+    );
+    assert!(
+        picked.len() > 1,
+        "the pick must be spread across candidates so one dead node does not hit every user"
+    );
+}
+
+#[test]
+fn closest_pick_still_prefers_the_better_score_tier_over_distance() {
+    let mut gateways: Vec<Gateway> = CLOSEST_IDS[..3]
+        .iter()
+        .enumerate()
+        .map(|(i, id)| gw_at_latitude(id, i as f64, ScoreValue::Medium))
+        .collect();
+    gateways.push(gw_at_latitude(CLOSEST_IDS[5], 80.0, ScoreValue::High));
+    let list = GatewayList::new(Some(GatewayType::Wg), gateways);
+
+    for _ in 0..50 {
+        let gw = list
+            .find_best_ordering_criteria_gateway(
+                latitude_distance_to_equator,
+                &GatewayFilters::default(),
+            )
+            .unwrap();
+        assert_eq!(gw.identity().to_base58_string(), CLOSEST_IDS[5]);
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -96,6 +96,9 @@ type Seed = [u8; 32];
 
 type Locale = String;
 
+/// Network-specific file (in `network_data_dir`) holding persisted blacklisted gateways.
+const BLACKLISTED_GATEWAYS_FILE: &str = "blacklisted_gateways.json";
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, strum::Display)]
 pub enum VpnServiceCommand {
@@ -709,6 +712,12 @@ impl NymVpnService {
             nym_vpn_api_client,
             tunnel_settings.clone(),
             wireguard_keys_db,
+            Some(
+                nym_config
+                    .paths
+                    .network_data_dir
+                    .join(BLACKLISTED_GATEWAYS_FILE),
+            ),
             state_machine_shutdown_token.child_token(),
         );
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -781,6 +781,20 @@ impl TunnelStateHandler for ConnectingState {
                         self.selected_gateways = None;
                         NextTunnelState::SameState(self)
                     }
+                    TunnelMonitorEvent::EntryHandshakeFailed { entry_gateway_id } => {
+                        // The entry WireGuard handshake never completed: the entry hop is dead
+                        // from this network, so blame it alone and pick another entry. The exit
+                        // was never reached and stays eligible.
+                        tracing::warn!(
+                            "Blacklisted entry gateway {entry_gateway_id}: WireGuard handshake never completed"
+                        );
+                        shared_state.gateway_provider.add_blacklisted_gateway(
+                            entry_gateway_id,
+                            BlacklistReason::EntryHandshakeFailed,
+                        ).await;
+                        self.selected_gateways = None;
+                        NextTunnelState::SameState(self)
+                    }
                     TunnelMonitorEvent::RegistrationFailed { gateway_id } => {
                         // Registration with the entry gateway failed; blacklist it to avoid
                         // re-selecting the same failing gateway.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -73,11 +73,14 @@ impl<C: GatewayCache> GatewayProvider<C> {
         geo_ip_client: impl GeoIpClient,
         tunnel_settings: TunnelSettings,
         wg_keys_db: WireguardKeysDb,
+        blacklist_path: Option<std::path::PathBuf>,
         shutdown_token: CancellationToken,
     ) -> (Self, JoinHandle<()>) {
         let latest_tunnel_settings = Arc::new(Mutex::new(tunnel_settings.clone()));
         let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
-        let blacklisted_gateways = BlacklistedGateways::new();
+        // Entry-side verdicts (dead entry hop from this network) are persisted so that a restart
+        // does not send the user back to the same unreachable gateway.
+        let blacklisted_gateways = BlacklistedGateways::load_or_new(blacklist_path);
         let (query_control_tx, query_control_rx) = mpsc::unbounded_channel();
         let (update_location_tx, update_location_rx) = mpsc::unbounded_channel();
 
@@ -297,7 +300,15 @@ impl<C: GatewayCache> GatewayProvider<C> {
         gateway_identifier: NodeIdentity,
         reason: BlacklistReason,
     ) {
-        if let Err(e) = self.blacklisted_gateways.add(gateway_identifier, reason) {
+        // Persisting the blacklist does file IO, so run it on a blocking worker rather than on
+        // the state machine task.
+        let blacklisted_gateways = self.blacklisted_gateways.clone();
+        let added = tokio::task::spawn_blocking(move || {
+            blacklisted_gateways.add(gateway_identifier, reason)
+        })
+        .await
+        .unwrap_or_else(|join_err| Err(anyhow::anyhow!("blacklist task panicked: {join_err}")));
+        if let Err(e) = added {
             tracing::error!(
                 "Failed to add gateway {} to blacklisted gateway list: {e}",
                 gateway_identifier

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
@@ -237,6 +237,7 @@ async fn error_stream() {
         MockGeoIpClient::new(),
         tunnel_settings,
         WireguardKeysDb::Ephemeral(Default::default()),
+        None,
         shutdown_token.child_token(),
     );
     // No gateways come out of the stream when there are no gateways to select from
@@ -264,6 +265,7 @@ async fn geo_location_disabled() {
         MockGeoIpClient::new(),
         tunnel_settings,
         WireguardKeysDb::Ephemeral(Default::default()),
+        None,
         shutdown_token.child_token(),
     );
     // No gateways come out of the stream when there are no gateways to select from
@@ -296,6 +298,7 @@ async fn set_and_stream() {
         MockGeoIpClient::new(),
         tunnel_settings,
         WireguardKeysDb::Ephemeral(Default::default()),
+        None,
         shutdown_token.child_token(),
     );
     gw_provider
@@ -338,6 +341,7 @@ async fn tentative_gateways_waits_for_fresh_selection_after_reset() {
         MockGeoIpClient::new(),
         tunnel_settings.clone(),
         WireguardKeysDb::Ephemeral(Default::default()),
+        None,
         shutdown_token.child_token(),
     );
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -216,6 +216,7 @@ impl ConnectedTunnel {
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
         let exit_stats_reader = exit_tunnel.stats_reader();
+        let entry_stats_reader = EntryStatsReader::TunTun(entry_tunnel.stats_reader());
 
         let event_handler_task = tokio::spawn(async move {
             #[cfg(windows)]
@@ -266,6 +267,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             exit_stats_reader,
+            entry_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -404,6 +406,7 @@ impl ConnectedTunnel {
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
         let exit_stats_reader = exit_tunnel.stats_reader();
+        let entry_stats_reader = EntryStatsReader::Netstack(entry_tunnel.stats_reader());
 
         let child_shutdown_token = shutdown_token.child_token();
         let event_handler_task = tokio::spawn(async move {
@@ -539,6 +542,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             exit_stats_reader,
+            entry_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -666,10 +670,29 @@ pub struct NetstackTunnelOptions {
     pub dns_filter: Option<DnsFilter>,
 }
 
+/// Live stats source for the entry WireGuard peer, which lives either in its own wireguard-go
+/// device (tun/tun multihop) or in the netstack device that wraps the exit tunnel.
+enum EntryStatsReader {
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    TunTun(wireguard_go::TunnelStatsReader),
+    Netstack(netstack::TunnelStatsReader),
+}
+
+impl EntryStatsReader {
+    fn get_stats(&self) -> nym_wg_go::Result<wireguard_go::TunnelStats> {
+        match self {
+            #[cfg(not(any(target_os = "ios", target_os = "android")))]
+            Self::TunTun(reader) => reader.get_stats(),
+            Self::Netstack(reader) => reader.get_stats(),
+        }
+    }
+}
+
 pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
     exit_stats_reader: wireguard_go::TunnelStatsReader,
+    entry_stats_reader: EntryStatsReader,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -692,6 +715,11 @@ impl TunnelHandle {
     /// Query live stats for the exit WireGuard peer via the UAPI GET interface.
     pub fn get_exit_stats(&self) -> nym_wg_go::Result<wireguard_go::TunnelStats> {
         self.exit_stats_reader.get_stats()
+    }
+
+    /// Query live stats for the entry WireGuard peer via the UAPI GET interface.
+    pub fn get_entry_stats(&self) -> nym_wg_go::Result<wireguard_go::TunnelStats> {
+        self.entry_stats_reader.get_stats()
     }
 
     /// Returns entry wintun interface descriptor when available.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -266,6 +266,13 @@ pub enum TunnelMonitorEvent {
         reply_tx: tokio::sync::oneshot::Sender<()>,
     },
 
+    /// The entry WireGuard handshake never completed, so the entry gateway is unreachable
+    /// from the current network. Nothing can be said about the exit gateway.
+    EntryHandshakeFailed {
+        /// Entry gateway whose handshake never completed.
+        entry_gateway_id: NodeIdentity,
+    },
+
     /// Connection has failed
     ConnectionFailed {
         /// Entry gateway used during the failed attempt.
@@ -406,6 +413,71 @@ async fn wait_for_exit_handshake(
         HandshakeWaitOutcome::Cancelled => {
             tracing::debug!(
                 "Shutdown requested while waiting for exit WireGuard handshake after {elapsed:.2?}"
+            );
+        }
+    }
+
+    outcome
+}
+
+/// How long the entry WireGuard peer gets to complete its handshake before the entry gateway is
+/// declared unreachable. wireguard-go retransmits the initiation every 5s, so this covers the
+/// first retransmission plus a generous round trip, while still failing a dead entry (e.g. its
+/// WG port blackholed on this network) in a fraction of the exit handshake + metadata windows.
+const ENTRY_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(7);
+
+/// What to do once the entry handshake wait is over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryHandshakeGate {
+    /// The entry hop answers; carry on with the exit handshake and the rest of the connect.
+    Proceed,
+    /// The entry hop never answered: it alone is to blame, fail the attempt right away.
+    BlameEntry,
+    /// Shutdown was requested while waiting; nobody is to blame, stop the connect.
+    Abort,
+}
+
+fn entry_handshake_gate(outcome: HandshakeWaitOutcome) -> EntryHandshakeGate {
+    match outcome {
+        HandshakeWaitOutcome::Completed => EntryHandshakeGate::Proceed,
+        HandshakeWaitOutcome::TimedOut => EntryHandshakeGate::BlameEntry,
+        HandshakeWaitOutcome::Cancelled => EntryHandshakeGate::Abort,
+    }
+}
+
+/// Poll the entry WireGuard peer's UAPI stats until the handshake completes or we time out.
+async fn wait_for_entry_handshake(
+    tunnel_handle: &connected_tunnel::TunnelHandle,
+    shutdown_token: &CancellationToken,
+) -> HandshakeWaitOutcome {
+    const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+    tracing::debug!("Waiting for entry WireGuard handshake to complete");
+
+    let started = std::time::Instant::now();
+
+    let outcome = wait_for_handshake_outcome(
+        || tunnel_handle.get_entry_stats(),
+        shutdown_token,
+        ENTRY_HANDSHAKE_TIMEOUT,
+        POLL_INTERVAL,
+    )
+    .await;
+
+    let elapsed = started.elapsed();
+    match outcome {
+        HandshakeWaitOutcome::Completed => {
+            tracing::debug!("Entry WireGuard handshake completed in {elapsed:.2?}");
+        }
+        HandshakeWaitOutcome::TimedOut => {
+            tracing::warn!(
+                "Entry WireGuard handshake did not complete within {:.1}s, entry gateway is unreachable",
+                elapsed.as_secs_f32()
+            );
+        }
+        HandshakeWaitOutcome::Cancelled => {
+            tracing::debug!(
+                "Shutdown requested while waiting for entry WireGuard handshake after {elapsed:.2?}"
             );
         }
     }
@@ -853,10 +925,30 @@ impl TunnelMonitor {
             tracing::warn!("Interface up reply timeout");
         }
 
-        // The firewall now allows traffic through the tunnel. Wait for the exit WG handshake.
+        // The firewall now allows traffic through the tunnel. First make sure the entry hop
+        // answers at all: an entry whose handshake never completes is dead from this network
+        // regardless of the exit, so it is failed fast and blamed alone instead of waiting out
+        // the exit handshake and metadata windows and blacklisting the exit first.
+        let mut abort_before_monitoring = false;
         let exit_handshake_completed = if let Some(wg_handle) = tunnel_handle.as_wireguard() {
-            wait_for_exit_handshake(wg_handle, &self.shutdown_token).await
-                == HandshakeWaitOutcome::Completed
+            let entry_outcome = wait_for_entry_handshake(wg_handle, &self.shutdown_token).await;
+            match entry_handshake_gate(entry_outcome) {
+                EntryHandshakeGate::Proceed => {
+                    wait_for_exit_handshake(wg_handle, &self.shutdown_token).await
+                        == HandshakeWaitOutcome::Completed
+                }
+                EntryHandshakeGate::BlameEntry => {
+                    self.send_event(TunnelMonitorEvent::EntryHandshakeFailed {
+                        entry_gateway_id: selected_gateways.entry_gateway().identity(),
+                    });
+                    abort_before_monitoring = true;
+                    false
+                }
+                EntryHandshakeGate::Abort => {
+                    abort_before_monitoring = true;
+                    false
+                }
+            }
         } else {
             // Mixnet tunnels have no WireGuard handshake to observe, so failures are
             // never attributed to the entry gateway based on it.
@@ -951,6 +1043,9 @@ impl TunnelMonitor {
         });
 
         loop {
+            if abort_before_monitoring {
+                break;
+            }
             tokio::select! {
                 event = tunnel_connection_monitor_rx.recv() => {
                     let Some(event) = event else {
@@ -2397,6 +2492,45 @@ mod tests {
             outcome,
             HandshakeWaitOutcome::Cancelled,
             "shutdown while waiting must not be reported as a completed handshake"
+        );
+    }
+
+    /// wireguard-go retransmits a handshake initiation every `RekeyTimeout` (5s).
+    const WIREGUARD_REKEY_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn entry_handshake_wait_covers_one_retransmission_but_stays_short() {
+        assert!(
+            ENTRY_HANDSHAKE_TIMEOUT > WIREGUARD_REKEY_TIMEOUT,
+            "a single lost initiation must not get the entry gateway blamed"
+        );
+        assert!(
+            ENTRY_HANDSHAKE_TIMEOUT <= Duration::from_secs(10),
+            "the whole point of the gate is to fail a dead entry in well under one exit-handshake window"
+        );
+    }
+
+    #[test]
+    fn entry_handshake_timeout_blames_the_entry() {
+        assert_eq!(
+            entry_handshake_gate(HandshakeWaitOutcome::TimedOut),
+            EntryHandshakeGate::BlameEntry
+        );
+    }
+
+    #[test]
+    fn completed_entry_handshake_proceeds() {
+        assert_eq!(
+            entry_handshake_gate(HandshakeWaitOutcome::Completed),
+            EntryHandshakeGate::Proceed
+        );
+    }
+
+    #[test]
+    fn cancelled_entry_handshake_wait_does_not_blame_anyone() {
+        assert_eq!(
+            entry_handshake_gate(HandshakeWaitOutcome::Cancelled),
+            EntryHandshakeGate::Abort
         );
     }
 }

--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -17,6 +17,7 @@ use nym_windows::net::AddressFamily;
 
 use super::{
     Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result, uapi::UapiConfigBuilder,
+    wireguard_go::TunnelStats,
 };
 #[cfg(feature = "amnezia")]
 use crate::amnezia::AmneziaConfig;
@@ -91,6 +92,31 @@ pub struct Tunnel {
     tunnel_handle: i32,
 }
 
+/// Reads live peer stats of a netstack WireGuard tunnel via the UAPI GET interface.
+///
+/// Once the owning [`Tunnel`] is stopped the Go side no longer knows the handle and
+/// [`TunnelStatsReader::get_stats`] fails with [`Error::GetUapiConfig`].
+#[derive(Debug, Clone)]
+pub struct TunnelStatsReader {
+    tunnel_handle: i32,
+}
+
+impl TunnelStatsReader {
+    pub fn get_stats(&self) -> Result<TunnelStats> {
+        if self.tunnel_handle < 0 {
+            return Err(Error::TunnelStopped);
+        }
+        let raw = unsafe { wgNetGetConfig(self.tunnel_handle) };
+        if raw.is_null() {
+            return Err(Error::GetUapiConfig);
+        }
+        let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
+        unsafe { wgFreePtr(raw as *mut c_void) };
+        tracing::trace!("Netstack TunnelStats: '{s}'");
+        Ok(TunnelStats::parse(&s))
+    }
+}
+
 impl Tunnel {
     pub fn start(config: Config) -> Result<Self> {
         let interface_mtu = config.interface.mtu;
@@ -116,6 +142,13 @@ impl Tunnel {
             Ok(Self { tunnel_handle })
         } else {
             Err(Error::StartTunnel(tunnel_handle))
+        }
+    }
+
+    /// Create a stats reader that can query live peer stats without owning the tunnel.
+    pub fn stats_reader(&self) -> TunnelStatsReader {
+        TunnelStatsReader {
+            tunnel_handle: self.tunnel_handle,
         }
     }
 
@@ -403,7 +436,6 @@ unsafe extern "C" {
     unsafe fn wgNetSetConfig(net_tunnel_handle: i32, settings: *const c_char) -> i64;
 
     /// Returns the config of the WireGuard interface.
-    #[allow(unused)]
     unsafe fn wgNetGetConfig(net_tunnel_handle: i32) -> *const c_char;
 
     /// Start UDP connection proxy through the netstack tunnel.
@@ -456,7 +488,6 @@ unsafe extern "C" {
     unsafe fn wgNetRebindTunnelSocket(address_family: u16, interface_index: u32);
 
     /// Frees a pointer allocated by the go runtime - useful to free return value of wgGetConfig
-    #[allow(unused)]
     unsafe fn wgFreePtr(ptr: *mut c_void);
 }
 

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -404,6 +404,11 @@ impl TunnelStats {
     pub fn all_peers_connected(&self) -> bool {
         !self.peers.is_empty() && self.peers.iter().all(|p| p.has_completed_handshake())
     }
+
+    /// Parse the textual UAPI `get=1` response of a WireGuard device.
+    pub fn parse(response: &str) -> Self {
+        TunnelStatsReader::parse_tunnel_stats(response)
+    }
 }
 
 pub struct TunnelStatsReader {
@@ -621,5 +626,40 @@ impl WgLogLevel {
             x if x == WgLogLevel::Verbose as u32 => Some(WgLogLevel::Verbose),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UAPI_TWO_PEERS: &str = "private_key=00\n\
+listen_port=51820\n\
+public_key=1111111111111111111111111111111111111111111111111111111111111111\n\
+endpoint=1.2.3.4:51820\n\
+last_handshake_time_sec=1700000000\n\
+last_handshake_time_nsec=5\n\
+rx_bytes=10\n\
+tx_bytes=20\n\
+public_key=2222222222222222222222222222222222222222222222222222222222222222\n\
+endpoint=5.6.7.8:51820\n\
+last_handshake_time_sec=0\n\
+last_handshake_time_nsec=0\n\
+rx_bytes=0\n\
+tx_bytes=30\n\
+errno=0\n";
+
+    #[test]
+    fn parse_reports_per_peer_handshake_state() {
+        let stats = TunnelStats::parse(UAPI_TWO_PEERS);
+
+        assert_eq!(stats.listen_port, Some(51820));
+        assert_eq!(stats.peers.len(), 2);
+        assert!(stats.peers[0].has_completed_handshake());
+        assert!(
+            !stats.peers[1].has_completed_handshake(),
+            "a zero handshake timestamp means the peer never handshaked"
+        );
+        assert!(!stats.all_peers_connected());
     }
 }


### PR DESCRIPTION
With the default now set to Safest, the client always picks the single High-score gateway geographically closest to the user, so everyone in a region lands on the same entry node first.

From China that node has its WireGuard UDP port blackholed while TCP still works, so registration succeeds and the connect stalls: the client waited out the exit handshake and metadata windows, blacklisted the exit rather than the entry, only blamed the entry after a second strike, and the 20-minute in-memory blacklist meant every app restart replayed the same failure. Three attempts took over a minute before the user saw an error, while a connect through a reachable entry takes about 10 seconds. 

- The first change watches the entry hop's own handshake and fails the attempt after 7 seconds when it never completes, blacklisting the entry alone, so a dead entry costs one short strike instead of two long ones. 

- The second change keeps entry-side verdicts on disk for 24 hours so a restart does not send the user back to the dead node, and picks randomly among the three closest gateways instead of always the closest, so one unreachable node no longer breaks the first connect for every user in a region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6282)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connection monitoring now verifies both gateway handshakes before completing setup.
  - Failed entry gateways are automatically excluded and remembered across app restarts.
  - Gateway selection now randomly chooses among the best available candidates for improved distribution.
  - Live statistics are available for both entry and exit tunnel connections.

- **Bug Fixes**
  - Improved recovery from entry-gateway handshake failures by retrying with alternative gateways.
  - Gateway blacklist entries now expire appropriately based on the failure type.
  - Blacklist data is restored safely after restart, while expired or invalid entries are discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->