### PR TITLE
Fix/core dead tunnel stalls

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1349,7 +1349,7 @@ impl NymVpnService {
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetRecentGateways(tx, gateway_type) => {
-                let _ = tx.send(self.handle_get_recent_gateways(gateway_type).await);
+                spawn_recent_gateways_lookup(self.recents_manager.clone(), gateway_type, tx);
             }
             VpnServiceCommand::SetProfile(tx, profile) => {
                 self.handle_set_profile(profile).await;
@@ -2471,18 +2471,88 @@ impl NymVpnService {
         Ok(())
     }
 
-    async fn handle_get_recent_gateways(
-        &mut self,
-        tunnel_type: TunnelType,
-    ) -> Result<RecentGateways, ListGatewaysError> {
-        self.recents_manager
-            .get_recent(tunnel_type)
-            .await
-            .map_err(ListGatewaysError::GetRecentGateways)
-    }
-
     async fn handle_set_profile(&mut self, profile: Profile) {
         self.config_manager.set_profile(profile).await;
         self.update_tunnel_settings_with_throttle();
+    }
+}
+
+/// Answer a recent-gateways request off the command loop.
+///
+/// The lookup goes through the gateway cache, which may refresh the directory over the network
+/// with a 30s timeout and retries; through a dead or slow tunnel that is minutes. The service
+/// loop handles one command at a time, so awaiting it inline stalled mode switches, status polls
+/// and even shutdown behind a UI read. Like the gateway list handlers, reply from a task instead.
+fn spawn_recent_gateways_lookup<C>(
+    recents_manager: RecentsManager<C>,
+    tunnel_type: TunnelType,
+    completion_tx: oneshot::Sender<Result<RecentGateways, ListGatewaysError>>,
+) where
+    C: nym_favorites::RecentGatewayCache + Clone + 'static,
+{
+    tokio::spawn(async move {
+        let result = recents_manager
+            .get_recent(tunnel_type)
+            .await
+            .map_err(ListGatewaysError::GetRecentGateways);
+        completion_tx.send(result).ok();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nym_favorites::RecentGatewayCache;
+    use nym_gateway_directory::{GatewayList, GatewayType};
+    use tokio::sync::{Notify, oneshot};
+
+    use super::*;
+
+    /// A gateway cache whose lookups hang until released, standing in for a directory refresh
+    /// that is stuck on a dead or slow tunnel.
+    #[derive(Clone)]
+    struct StalledCache {
+        release: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl RecentGatewayCache for StalledCache {
+        async fn lookup_gateways(
+            &self,
+            gw_type: GatewayType,
+        ) -> Result<GatewayList, nym_gateway_directory::Error> {
+            self.release.notified().await;
+            Ok(GatewayList::new(Some(gw_type), vec![]))
+        }
+    }
+
+    #[tokio::test]
+    async fn recent_gateways_lookup_does_not_block_the_caller_while_the_cache_is_stalled() {
+        let dir = tempfile::tempdir().unwrap();
+        let release = Arc::new(Notify::new());
+        let recents_manager = RecentsManager::new(
+            dir.path().to_path_buf(),
+            StalledCache {
+                release: release.clone(),
+            },
+        )
+        .await;
+        let (tx, mut rx) = oneshot::channel();
+
+        // Must return at once: the command loop calling this has other commands to drain.
+        spawn_recent_gateways_lookup(recents_manager, TunnelType::Wireguard, tx);
+        assert!(
+            matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+            "the lookup is still stalled, so no answer yet, but the caller already got control back"
+        );
+
+        release.notify_waiters();
+        release.notify_one();
+        let recents = rx
+            .await
+            .expect("lookup task dropped the reply channel")
+            .unwrap();
+        assert!(recents.entry.is_empty() && recents.exit.is_empty());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -82,6 +82,49 @@ pub fn should_defer_probe_teardown(
         && health.is_some_and(|h| h.is_recently_healthy(grace))
 }
 
+/// What the tunnel monitor does with a connectivity probe `Failed` verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeFailureAction {
+    /// The in-tunnel metadata path succeeded recently and the deferral budget is not spent:
+    /// give the probe another interval before believing it.
+    DeferTeardown,
+    /// The deferral budget is spent but the metadata path is still fresh: keep the tunnel.
+    KeepAlive,
+    /// Nothing vouches for the tunnel any more: tear it down.
+    TearDown,
+}
+
+impl ProbeFailureAction {
+    /// Whether the next `Failed` verdict must be evaluated afresh instead of being dropped as a
+    /// repeat of this one. Only a teardown ends the story; the other two outcomes hinge on the
+    /// metadata grace window, which expires with time, so a repeated `Failed` status must reach
+    /// the decision again or a dead tunnel stays "connected" forever.
+    pub fn reevaluates_next_failure(self) -> bool {
+        !matches!(self, Self::TearDown)
+    }
+}
+
+/// Decide what a connectivity probe `Failed` verdict means for the tunnel.
+pub fn probe_failure_action(
+    uses_metadata_endpoint: bool,
+    health: Option<&MetadataPathHealth>,
+    grace: Duration,
+    consecutive_deferred_failures: u32,
+) -> ProbeFailureAction {
+    if should_defer_probe_teardown(
+        uses_metadata_endpoint,
+        health,
+        grace,
+        consecutive_deferred_failures,
+    ) {
+        ProbeFailureAction::DeferTeardown
+    } else if should_treat_metadata_as_connect_viable(uses_metadata_endpoint, health, grace) {
+        ProbeFailureAction::KeepAlive
+    } else {
+        ProbeFailureAction::TearDown
+    }
+}
+
 /// Update metadata-path health from a bandwidth check interval.
 ///
 /// Records success only when both legs succeed; clears any prior success when either leg fails
@@ -225,5 +268,55 @@ mod tests {
             Some(&health),
             METADATA_PATH_HEALTH_GRACE,
         ));
+    }
+
+    fn healthy_now() -> MetadataPathHealth {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        health
+    }
+
+    #[test]
+    fn probe_failure_is_deferred_while_budget_remains_and_metadata_is_fresh() {
+        assert_eq!(
+            probe_failure_action(true, Some(&healthy_now()), METADATA_PATH_HEALTH_GRACE, 0),
+            ProbeFailureAction::DeferTeardown
+        );
+    }
+
+    #[test]
+    fn probe_failure_keeps_tunnel_alive_once_budget_is_spent_but_metadata_is_fresh() {
+        assert_eq!(
+            probe_failure_action(
+                true,
+                Some(&healthy_now()),
+                METADATA_PATH_HEALTH_GRACE,
+                MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
+            ),
+            ProbeFailureAction::KeepAlive
+        );
+    }
+
+    #[test]
+    fn probe_failure_tears_down_when_nothing_vouches_for_the_tunnel() {
+        let stale = MetadataPathHealth::new();
+        assert_eq!(
+            probe_failure_action(true, Some(&stale), METADATA_PATH_HEALTH_GRACE, 0),
+            ProbeFailureAction::TearDown
+        );
+        assert_eq!(
+            probe_failure_action(false, Some(&healthy_now()), METADATA_PATH_HEALTH_GRACE, 0),
+            ProbeFailureAction::TearDown,
+            "mixnet tunnels have no metadata path to vouch for them"
+        );
+    }
+
+    #[test]
+    fn every_outcome_that_keeps_the_tunnel_must_reevaluate_the_next_failure() {
+        // Regression: a dead tunnel stayed "Connected" for minutes because a KeepAlive verdict
+        // left the repeated `Failed` status deduplicated, so the grace expiry was never noticed.
+        assert!(ProbeFailureAction::DeferTeardown.reevaluates_next_failure());
+        assert!(ProbeFailureAction::KeepAlive.reevaluates_next_failure());
+        assert!(!ProbeFailureAction::TearDown.reevaluates_next_failure());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -86,7 +86,7 @@ use crate::{
     bandwidth_monitor::BandwidthMonitor,
     mixnet::VpnTopologyServiceHandle,
     tunnel_health::{
-        METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, should_defer_probe_teardown,
+        METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, ProbeFailureAction, probe_failure_action,
         should_treat_metadata_as_connect_viable,
     },
     tunnel_state_machine::{
@@ -978,37 +978,45 @@ impl TunnelMonitor {
                                 tracing::info!("Tunnel connection is failing (retry: {retry})");
                             }
                             ConnectionStatusEvent::Failed => {
-                                if should_defer_probe_teardown(
+                                let action = probe_failure_action(
                                     uses_metadata_endpoint,
                                     metadata_path_health.as_ref(),
                                     METADATA_PATH_HEALTH_GRACE,
                                     consecutive_deferred_probe_failures,
-                                ) {
-                                    consecutive_deferred_probe_failures =
-                                        consecutive_deferred_probe_failures.saturating_add(1);
-                                    tracing::warn!(
-                                        consecutive_deferred_probe_failures,
-                                        max_consecutive_deferred_probe_failures =
-                                            crate::tunnel_health::MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
-                                        "Probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
-                                    );
+                                );
+                                if action.reevaluates_next_failure() {
+                                    // The verdict depends on the metadata grace window, so the
+                                    // next `Failed` must not be dropped as a duplicate.
                                     last_connection_status = None;
-                                } else if should_treat_metadata_as_connect_viable(
-                                    uses_metadata_endpoint,
-                                    metadata_path_health.as_ref(),
-                                    METADATA_PATH_HEALTH_GRACE,
-                                ) {
-                                    if !has_sent_up_event {
-                                        tracing::info!(
-                                            "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
+                                }
+                                match action {
+                                    ProbeFailureAction::DeferTeardown => {
+                                        consecutive_deferred_probe_failures =
+                                            consecutive_deferred_probe_failures.saturating_add(1);
+                                        tracing::warn!(
+                                            consecutive_deferred_probe_failures,
+                                            max_consecutive_deferred_probe_failures =
+                                                crate::tunnel_health::MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
+                                            "Probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
                                         );
-                                        has_sent_up_event = true;
-                                        self.send_event(TunnelMonitorEvent::Up {
-                                            tunnel_interface: tunnel_interface.clone(),
-                                            connection_data: connection_data.clone(),
-                                        });
                                     }
-                                } else {
+                                    ProbeFailureAction::KeepAlive => {
+                                        if !has_sent_up_event {
+                                            tracing::info!(
+                                                "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
+                                            );
+                                            has_sent_up_event = true;
+                                            self.send_event(TunnelMonitorEvent::Up {
+                                                tunnel_interface: tunnel_interface.clone(),
+                                                connection_data: connection_data.clone(),
+                                            });
+                                        } else {
+                                            tracing::warn!(
+                                                "Probe keeps failing; keeping tunnel only while the in-tunnel metadata path stays fresh"
+                                            );
+                                        }
+                                    }
+                                    ProbeFailureAction::TearDown => {
                                     tracing::info!("Tunnel connection is down. Exiting");
                                     let exit_handshake_completed = match tunnel_handle.as_wireguard() {
                                         Some(wg) => exit_handshake_completed_now(exit_handshake_completed, || wg.get_exit_stats()),
@@ -1024,6 +1032,7 @@ impl TunnelMonitor {
                                         exit_handshake_completed,
                                     });
                                     break;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6283)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VPN responsiveness by allowing recent gateway lookups to run without blocking other service operations.
  - Improved tunnel stability during temporary connectivity probe failures by deferring teardown when recovery remains possible.
  - Tunnels can now remain active when metadata connectivity is still fresh, while continued failures are re-evaluated to ensure unhealthy connections are eventually closed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->