### PR TITLE
Avoid blocking daemon command loop when handling recents

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retry zk-nym credential requests when upstream is unavailable mid-ceremony (https://github.com/nymtech/nym-vpn-client/pull/6258)
 - Prevent gateway refresh storm when the API is unreachable (https://github.com/nymtech/nym-vpn-client/pull/6087)
 - [Windows] Wait for the VPN service to be running after install (https://github.com/nymtech/nym-vpn-client/pull/6245)
+- Avoid blocking daemon command loop when handling recents which may perform network calls (https://github.com/nymtech/nym-vpn-client/pull/6294)
+
 
 ## [2026.12.3] - 2026-08-27
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1349,7 +1349,7 @@ impl NymVpnService {
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetRecentGateways(tx, gateway_type) => {
-                let _ = tx.send(self.handle_get_recent_gateways(gateway_type).await);
+                self.handle_get_recent_gateways(tx, gateway_type);
             }
             VpnServiceCommand::SetProfile(tx, profile) => {
                 self.handle_set_profile(profile).await;
@@ -2471,14 +2471,19 @@ impl NymVpnService {
         Ok(())
     }
 
-    async fn handle_get_recent_gateways(
-        &mut self,
+    fn handle_get_recent_gateways(
+        &self,
+        tx: oneshot::Sender<Result<RecentGateways, ListGatewaysError>>,
         tunnel_type: TunnelType,
-    ) -> Result<RecentGateways, ListGatewaysError> {
-        self.recents_manager
-            .get_recent(tunnel_type)
-            .await
-            .map_err(ListGatewaysError::GetRecentGateways)
+    ) {
+        let recents_manager = self.recents_manager.clone();
+        tokio::spawn(async move {
+            let res = recents_manager
+                .get_recent(tunnel_type)
+                .await
+                .map_err(ListGatewaysError::GetRecentGateways);
+            let _ = tx.send(res);
+        });
     }
 
     async fn handle_set_profile(&mut self, profile: Profile) {


### PR DESCRIPTION


## Description

Since `RecentsManager::get_recent` may perform network call, we should wrap it in `tokio::spawn`

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6294)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Recent gateway lookups now run asynchronously, so VPN commands remain responsive while recents are being retrieved.
  - Results and lookup errors continue to be returned once processing completes.

- **Documentation**
  - Added an unreleased changelog entry describing the improved handling of recent gateway retrievals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->