### PR TITLE
Remove failed pending requests before creating new ones

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent gateway refresh storm when the API is unreachable (https://github.com/nymtech/nym-vpn-client/pull/6087)
 - [Windows] Wait for the VPN service to be running after install (https://github.com/nymtech/nym-vpn-client/pull/6245)
 - Avoid blocking daemon command loop when handling recents which may perform network calls (https://github.com/nymtech/nym-vpn-client/pull/6294)
-
+- Remove failed pending requests before creating new ones (https://github.com/nymtech/nym-vpn-client/pull/6295)
 
 ## [2026.12.3] - 2026-08-27
 

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/credential_request.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/src/credential_request.rs
@@ -88,6 +88,15 @@ impl CredentialRequestTask {
                 pending_request.id
             );
             return self.finalize_zk_nym_request(pending_request).await;
+        } else if let failed_pending = self.failed_requests_of_type(ticketbook_type).await?
+            && !failed_pending.is_empty()
+        {
+            // do a cleanup of pending requests before creating new ones
+            for p in failed_pending {
+                if let Err(err) = self.pending_storage.remove_pending_request(&p.id).await {
+                    tracing::warn!("Could not remove failed pending request: {err}");
+                }
+            }
         }
 
         let pending_request = self.create_pending_zk_nym_request(ticketbook_type).await?;
@@ -296,6 +305,51 @@ impl CredentialRequestTask {
         Ok(pending
             .into_iter()
             .find(|request| available_ids.contains(&request.id)))
+    }
+
+    async fn failed_requests_of_type(
+        &self,
+        ticketbook_type: TicketType,
+    ) -> Result<Vec<PendingCredentialRequest>, VpnApiFetcherError> {
+        let pending = self.pending_storage.get_pending_requests().await?;
+
+        if pending.is_empty() {
+            // early return to avoid unnecessary network call
+            return Ok(vec![]);
+        }
+
+        let ticketbook_type = ticketbook_type.to_string();
+        let all_ids = self
+            .vpn_api_client
+            .get_device_zk_nyms(&self.account, &self.device)
+            .await
+            .map_err(VpnApiFetcherError::vpn_api_error("get_device_zk_nyms"))?
+            .items
+            .into_iter()
+            .map(
+                |NymVpnZkNym {
+                     id,
+                     status,
+                     ticketbook_type,
+                     ..
+                 }| { (id, (ticketbook_type, status)) },
+            )
+            .collect::<HashMap<_, _>>();
+        let failed_pending = pending
+            .into_iter()
+            .filter(|p| {
+                let Some((typ, status)) = all_ids.get(&p.id) else {
+                    return true;
+                };
+                if *typ != ticketbook_type {
+                    return false;
+                }
+                matches!(status, NymVpnZkNymStatus::Error)
+                    || matches!(status, NymVpnZkNymStatus::Revoked)
+            })
+            .collect();
+
+        Ok(failed_pending)
     }
 
     /// Returns the `(id, ticketbook_type)` of every zk-nym the API has ready for us to download.


### PR DESCRIPTION
## Ticket

JIRA-NYM-1770

## Description

Pending requests were leaking in storage when zk-nym queries were failing due to quorum issues upstream of credential proxy.
Make sure to do a cleanup of failed and revoked pending requests before creating new ones

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6295)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed, revoked, or missing credential requests are now cleared before a new request is created.
  - Users can retry credential requests without being blocked by stale pending requests.
  - Cleanup issues no longer prevent a new credential request from being submitted.
  - Recent-item handling no longer blocks other daemon commands during network operations.

- **Documentation**
  - Added an unreleased changelog entry covering the updated request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->