### PR TITLE
Poll terminal account errors hourly and reuse the cached VPN API clock

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Poll terminal account errors every hour instead of every two minutes, and reuse the cached VPN API clock on summary fetch.
 - [macOS] Sign cli with net.nymtech.vpn.cli bundle identifier. Add it to client signing requirement. (https://github.com/nymtech/nym-vpn-client/pull/5998)
 - Merge rpc-uniffi crate into lib-uniffi (https://github.com/nymtech/nym-vpn-client/pull/6010)
 - Remove "trace only logging" mode and honor `RUST_LOG` when set (https://github.com/nymtech/nym-vpn-client/pull/6131)

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -50,6 +50,7 @@ url.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 rand.workspace = true
 nym-compact-ecash.workspace = true
 nym-credential-proxy-requests.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -7,9 +7,9 @@ use crate::{
     SharedAccountState,
     commands::{AccountCommand, common_handler, handler},
     state_machine::{
-        ACCOUNT_UPDATE_INTERVAL_ERROR, AccountControllerStateHandler, LoggedOutState,
-        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
-        SyncingNetworkState,
+        ACCOUNT_UPDATE_INTERVAL_ERROR, ACCOUNT_UPDATE_INTERVAL_ERROR_TERMINAL,
+        AccountControllerStateHandler, LoggedOutState, NextAccountControllerState, OfflineState,
+        PrivateAccountControllerState, SyncMode, SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -46,7 +46,12 @@ impl ErrorState {
         // fetcher around trying to top up.
         let _ = shared_state.clear_credential_fetcher().await;
 
-        let refresh_timer = Box::pin(tokio::time::sleep(ACCOUNT_UPDATE_INTERVAL_ERROR));
+        let refresh_after = if reason.is_retryable() {
+            ACCOUNT_UPDATE_INTERVAL_ERROR
+        } else {
+            ACCOUNT_UPDATE_INTERVAL_ERROR_TERMINAL
+        };
+        let refresh_timer = Box::pin(tokio::time::sleep(refresh_after));
         tracing::error!("Account Controller entering error state : {reason:#?}");
         (
             Box::new(Self {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
@@ -46,6 +46,9 @@ pub(crate) use decentralised_state::DecentralisedState;
 // The interval at which we update the account state when in error state
 const ACCOUNT_UPDATE_INTERVAL_ERROR: Duration = Duration::from_secs(2 * 60);
 
+// Terminal (non-retryable) error. Named so Ready can change independently.
+const ACCOUNT_UPDATE_INTERVAL_ERROR_TERMINAL: Duration = Duration::from_secs(60 * 60);
+
 // The interval at which we update the account state when in ready state
 const ACCOUNT_UPDATE_INTERVAL_READY: Duration = Duration::from_secs(60 * 60);
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -18,11 +18,12 @@ use nym_vpn_api_client::{
     VpnApiClient,
     error::VpnApiClientError,
     response::NymErrorResponse,
-    types::{Device, VpnAccount},
+    types::{Device, VpnAccount, VpnApiTime},
 };
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
 };
+use time::OffsetDateTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -161,7 +162,13 @@ impl SyncingNetworkState {
         // Fetch the remote time so the summary can record whether our clock is acceptably synced
         // (a desync would make zk-nyms fail to verify on gateways). The desync itself is surfaced
         // later, during the local checks, via `VpnAccountSummary::time_synced`.
-        let remote_time = vpn_api_client.get_remote_time().await?;
+        let remote_time = match vpn_api_client.current_remote_time().await? {
+            Some(t) => t,
+            None => {
+                let now = OffsetDateTime::now_utc();
+                VpnApiTime::from_estimated_remote_time(now, now)
+            }
+        };
 
         let summary = vpn_api_client
             .get_account_summary_with_device(vpn_api_account, device)

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::time::Duration;
+
 use crate::common::{TestBench, account_summary::*, endpoints, nyxd_endpoints};
 
 use nym_vpn_api_client::response::NymVpnDeviceStatus;
@@ -499,4 +501,124 @@ async fn optimistic_refresh_falls_back_but_force_refresh_surfaces_error_test() -
         ))
         .await;
     Ok(())
+}
+
+#[tokio::test]
+async fn error_timer_inactive_subscription_skips_two_minute_poll() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_with_inactive_sub()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::InactiveSubscription,
+        ))
+        .await;
+
+    let before = vpn_api_request_count(&test_bench).await;
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(2 * 60 + 1)).await;
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    let after = vpn_api_request_count(&test_bench).await;
+    assert_eq!(
+        before, after,
+        "non-retryable Error must not poll at the 2-minute interval"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn error_timer_api_failure_resyncs_after_two_minutes() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_403(unrelated_error()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::ApiFailure {
+                context: "SYNCING_NETWORK_STATE".into(),
+                details: "API returned an error: 55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
+            },
+        ))
+        .await;
+
+    let before = vpn_api_request_count(&test_bench).await;
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(2 * 60 + 1)).await;
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    let after = vpn_api_request_count(&test_bench).await;
+    assert!(
+        after > before,
+        "ApiFailure must still poll at the 2-minute interval (before={before}, after={after})"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn fetch_summary_reuses_cached_remote_time() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_with_inactive_sub()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::InactiveSubscription,
+        ))
+        .await;
+
+    let health_before = health_request_count(&test_bench).await;
+    assert!(health_before > 0, "first sync must hit /health");
+
+    assert_eq!(
+        test_bench.command_sender.refresh_account_state(false).await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::InactiveSubscription,
+        ))
+        .await;
+
+    let health_after = health_request_count(&test_bench).await;
+    assert_eq!(
+        health_before, health_after,
+        "second fetch_summary must reuse the skew cache"
+    );
+    Ok(())
+}
+
+async fn vpn_api_request_count(test_bench: &TestBench) -> usize {
+    test_bench
+        .vpn_api_server
+        .received_requests()
+        .await
+        .map(|requests| requests.len())
+        .unwrap_or(0)
+}
+
+async fn health_request_count(test_bench: &TestBench) -> usize {
+    test_bench
+        .vpn_api_server
+        .received_requests()
+        .await
+        .map(|requests| {
+            requests
+                .iter()
+                .filter(|request| request.url.path() == "/public/v1/health")
+                .count()
+        })
+        .unwrap_or(0)
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -152,6 +152,10 @@ impl VpnApiClient {
         self.skew_manager.get_remote_time().await
     }
 
+    pub async fn current_remote_time(&self) -> Result<Option<VpnApiTime>> {
+        self.skew_manager.current_remote_time().await
+    }
+
     async fn device_time(&self) -> OffsetDateTime {
         self.skew_manager.device_time()
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -10,7 +10,7 @@ use nym_vpn_account_controller::{CreateDeeplinkParams, Deeplink};
 use nym_vpn_api_client::{
     VpnApiClient,
     response::NymVpnRegisterAccountResponse,
-    types::{Device, DeviceStatus, Platform, VpnAccount, VpnAccountMode},
+    types::{Device, DeviceStatus, Platform, VpnAccount, VpnAccountMode, VpnApiTime},
 };
 use nym_vpn_lib::storage::VpnClientOnDiskStorage;
 use nym_vpn_lib_types::{
@@ -23,6 +23,7 @@ use nym_vpn_store::{
     account_summary::AccountSummaryStorage,
     keys::{device::DeviceKeyStore, wireguard::DB_NAME},
 };
+use time::OffsetDateTime;
 
 use crate::{NymEnvironment, VpnError, deeplink::NymDeeplinkMnemonic};
 
@@ -417,13 +418,17 @@ impl NymVpnAccountStorage {
 
         // Each call uses the VPN API client HTTP timeout (`NYM_VPN_API_TIMEOUT`, 30s in
         // `nym-vpn-api-client/src/client.rs`).
-        let remote_time =
-            vpn_api_client
-                .get_remote_time()
-                .await
-                .map_err(|err| VpnError::InternalError {
-                    details: format!("Failed to get remote time: {err}"),
-                })?;
+        let remote_time = match vpn_api_client.current_remote_time().await.map_err(|err| {
+            VpnError::InternalError {
+                details: format!("Failed to get remote time: {err}"),
+            }
+        })? {
+            Some(t) => t,
+            None => {
+                let now = OffsetDateTime::now_utc();
+                VpnApiTime::from_estimated_remote_time(now, now)
+            }
+        };
 
         let api_summary = vpn_api_client
             .get_account_summary_with_device(account, device)


### PR DESCRIPTION
## Description

- Background sync for terminal account errors (inactive, expired, never paid) runs once an hour instead of every two minutes.
- Transient API failures and pending cash payments still retry every two minutes.
- Account summary uses the cached API clock instead of calling health on every sync.
- Refresh, foreground, in-app purchase, and connect still sync immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6304)
<!-- Reviewable:end -->
