### PR TITLE
Cherry pick Entry handshake check (#6308)

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Respect the gateway blacklist for "pinned gateways" (https://github.com/nymtech/nym-vpn-client/pull/6272)
+- Verify the entry handshake and blacklist entry early if needed (https://github.com/nymtech/nym-vpn-client/pull/6308)
 
 ### Fixed
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/blacklisted_gateways.rs
@@ -20,6 +20,9 @@ pub enum BlacklistReason {
     EntryBlamedForRepeatedFailures,
     /// Registration with this gateway failed.
     RegistrationFailed,
+    /// The WG handshake with this entry gateway never completed: the entry hop is dead from
+    /// the current network (e.g. its WG port is blackholed), regardless of the exit gateway.
+    EntryHandshakeFailed,
 }
 
 impl fmt::Display for BlacklistReason {
@@ -30,6 +33,7 @@ impl fmt::Display for BlacklistReason {
                 write!(f, "blamed for repeated pre-handshake failures")
             }
             Self::RegistrationFailed => write!(f, "registration failed"),
+            Self::EntryHandshakeFailed => write!(f, "entry WireGuard handshake failed"),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -710,6 +710,12 @@ pub struct GatewayList {
     gateways: Vec<Gateway>,
 }
 
+/// How many of the best-ranked gateways an ordering-criteria selection (e.g. "closest to the
+/// user") picks from at random. Always taking the single best one sends every user in a region
+/// to the same node, so one gateway that is unreachable from that region breaks the first
+/// connect for all of them; spreading over a few also evens out load.
+pub const CLOSEST_GATEWAY_CANDIDATES: usize = 3;
+
 impl GatewayList {
     pub fn new(gw_type: Option<GatewayType>, gateways: Vec<Gateway>) -> Self {
         GatewayList { gw_type, gateways }
@@ -778,6 +784,24 @@ impl GatewayList {
         F: FnMut(&Gateway, &Gateway) -> Ordering,
     {
         self.filter(filters).into_iter().min_by(cmp)
+    }
+
+    /// Pick one of the `candidates` smallest gateways under `cmp`, uniformly at random.
+    pub fn filtered_random_among_min_by<F>(
+        &self,
+        filters: &GatewayFilters,
+        cmp: F,
+        candidates: usize,
+    ) -> Option<Gateway>
+    where
+        F: FnMut(&Gateway, &Gateway) -> Ordering,
+    {
+        let mut filtered = self.filter(filters);
+        filtered.sort_by(cmp);
+        filtered
+            .into_iter()
+            .take(candidates)
+            .choose(&mut rand::thread_rng())
     }
 
     pub fn retain_gateways_by<F>(&mut self, pred: F)
@@ -945,7 +969,11 @@ impl GatewayList {
 
             let filters = base_filters.with(&[GatewayFilter::MinScore(score)]);
 
-            if let Some(gateway) = self.filtered_min_by(&filters, &mut ordering_criteria) {
+            if let Some(gateway) = self.filtered_random_among_min_by(
+                &filters,
+                &mut ordering_criteria,
+                CLOSEST_GATEWAY_CANDIDATES,
+            ) {
                 return Ok(gateway);
             }
         }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -655,3 +655,99 @@ fn create_response_nym_gateway(
         family_data: None,
     }
 }
+
+fn gw_at_latitude(id: &str, latitude: f64, score: ScoreValue) -> Gateway {
+    Gateway::builder()
+        .identity(NodeIdentity::from_base58_string(id).unwrap())
+        .location(Location {
+            two_letter_iso_country_code: "XX".to_owned(),
+            latitude,
+            longitude: 0.0,
+            city: String::new(),
+            region: String::new(),
+            asn: None,
+        })
+        .performance(Performance {
+            last_updated_utc: String::new(),
+            score,
+            mixnet_score: score,
+            load: ScoreValue::Low,
+            uptime_percentage_last_24_hours: 1f32,
+        })
+        .build()
+}
+
+fn latitude_distance_to_equator(gw1: &Gateway, gw2: &Gateway) -> std::cmp::Ordering {
+    let lat = |gw: &Gateway| {
+        gw.location
+            .as_ref()
+            .map(|l| l.latitude.abs())
+            .unwrap_or(f64::MAX)
+    };
+    lat(gw1).total_cmp(&lat(gw2))
+}
+
+const CLOSEST_IDS: [&str; 6] = [
+    "24h2yanCFU5iy7xNQmW6RowFa6EzmAYQdM1bs8Y1X6iH",
+    "26ZmTxTVBKHZg8MTKwypHkXZVJhDC7QHuv3BdsyRyTuk",
+    "27GwHdmXLULVieyXmxZ6v9DHzRJtTEjfode1dzbptEAK",
+    "28tXg9mEW4mifgU1TdetVVAN5PvmhtLpHzFRMfJBT6ND",
+    "29U3LythwEaqigL5YajXALw1c7DE7YNcRW7Vn7KcYMQL",
+    "2aZj5UjC4N3SMjfJNjFiaHPqg1sgKDBYwaLozxGePQxW",
+];
+
+#[test]
+fn closest_pick_is_spread_over_the_nearest_candidates_only() {
+    // Gateways sit at increasing distance from the reference (the equator).
+    let gateways = CLOSEST_IDS
+        .iter()
+        .enumerate()
+        .map(|(i, id)| gw_at_latitude(id, i as f64 * 10.0, ScoreValue::High))
+        .collect();
+    let list = GatewayList::new(Some(GatewayType::Wg), gateways);
+
+    let mut picked = std::collections::HashSet::new();
+    for _ in 0..300 {
+        let gw = list
+            .find_best_ordering_criteria_gateway(
+                latitude_distance_to_equator,
+                &GatewayFilters::default(),
+            )
+            .unwrap();
+        picked.insert(gw.identity().to_base58_string());
+    }
+
+    let nearest: std::collections::HashSet<String> = CLOSEST_IDS[..CLOSEST_GATEWAY_CANDIDATES]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        picked.is_subset(&nearest),
+        "only the {CLOSEST_GATEWAY_CANDIDATES} nearest gateways may be picked, got {picked:?}"
+    );
+    assert!(
+        picked.len() > 1,
+        "the pick must be spread across candidates so one dead node does not hit every user"
+    );
+}
+
+#[test]
+fn closest_pick_still_prefers_the_better_score_tier_over_distance() {
+    let mut gateways: Vec<Gateway> = CLOSEST_IDS[..3]
+        .iter()
+        .enumerate()
+        .map(|(i, id)| gw_at_latitude(id, i as f64, ScoreValue::Medium))
+        .collect();
+    gateways.push(gw_at_latitude(CLOSEST_IDS[5], 80.0, ScoreValue::High));
+    let list = GatewayList::new(Some(GatewayType::Wg), gateways);
+
+    for _ in 0..50 {
+        let gw = list
+            .find_best_ordering_criteria_gateway(
+                latitude_distance_to_equator,
+                &GatewayFilters::default(),
+            )
+            .unwrap();
+        assert_eq!(gw.identity().to_base58_string(), CLOSEST_IDS[5]);
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -781,6 +781,20 @@ impl TunnelStateHandler for ConnectingState {
                         self.selected_gateways = None;
                         NextTunnelState::SameState(self)
                     }
+                    TunnelMonitorEvent::EntryHandshakeFailed { entry_gateway_id } => {
+                        // The entry WireGuard handshake never completed: the entry hop is dead
+                        // from this network, so blame it alone and pick another entry. The exit
+                        // was never reached and stays eligible.
+                        tracing::warn!(
+                            "Blacklisted entry gateway {entry_gateway_id}: WireGuard handshake never completed"
+                        );
+                        shared_state.gateway_provider.add_blacklisted_gateway(
+                            entry_gateway_id,
+                            BlacklistReason::EntryHandshakeFailed,
+                        ).await;
+                        self.selected_gateways = None;
+                        NextTunnelState::SameState(self)
+                    }
                     TunnelMonitorEvent::RegistrationFailed { gateway_id } => {
                         // Registration with the entry gateway failed; blacklist it to avoid
                         // re-selecting the same failing gateway.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -22,7 +22,7 @@ use nym_routing::{Callback, CallbackHandle, EventType};
 use nym_wg_go::wireguard_go::TunnelFd;
 #[cfg(windows)]
 use nym_wg_go::wireguard_go::WintunInterface;
-use nym_wg_go::{amnezia::AmneziaConfig, netstack, wireguard_go};
+use nym_wg_go::{amnezia::AmneziaConfig, netstack, stats::StatsReader, wireguard_go};
 #[cfg(windows)]
 use nym_windows::net::{self as winnet, AddressFamily};
 #[cfg(any(windows, target_os = "ios"))]
@@ -215,7 +215,8 @@ impl ConnectedTunnel {
         let wintun_entry_interface = entry_tunnel.wintun_interface().clone();
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
-        let exit_stats_reader = exit_tunnel.stats_reader();
+        let entry_stats_reader = Box::new(entry_tunnel.stats_reader());
+        let exit_stats_reader = Box::new(exit_tunnel.stats_reader());
 
         let event_handler_task = tokio::spawn(async move {
             #[cfg(windows)]
@@ -265,6 +266,7 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
+            entry_stats_reader,
             exit_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
@@ -403,7 +405,8 @@ impl ConnectedTunnel {
 
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
-        let exit_stats_reader = exit_tunnel.stats_reader();
+        let entry_stats_reader = Box::new(entry_tunnel.stats_reader());
+        let exit_stats_reader = Box::new(exit_tunnel.stats_reader());
 
         let child_shutdown_token = shutdown_token.child_token();
         let event_handler_task = tokio::spawn(async move {
@@ -538,6 +541,7 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
+            entry_stats_reader,
             exit_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: None,
@@ -669,7 +673,8 @@ pub struct NetstackTunnelOptions {
 pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
-    exit_stats_reader: wireguard_go::TunnelStatsReader,
+    entry_stats_reader: Box<dyn StatsReader + Send + Sync>,
+    exit_stats_reader: Box<dyn StatsReader + Send + Sync>,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -687,6 +692,11 @@ impl TunnelHandle {
     /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
     pub async fn wait(self) -> Result<Tombstone, JoinError> {
         self.event_handler_task.await
+    }
+
+    /// Query live stats for the entry WireGuard peer via the UAPI GET interface.
+    pub fn get_entry_stats(&self) -> nym_wg_go::Result<wireguard_go::TunnelStats> {
+        self.entry_stats_reader.get_stats()
     }
 
     /// Query live stats for the exit WireGuard peer via the UAPI GET interface.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -29,7 +29,7 @@ use nym_gateway_directory::{
 };
 use time::OffsetDateTime;
 use tokio::{sync::mpsc, task::JoinHandle};
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, DropGuard};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use tun::AbstractDevice;
 #[cfg(windows)]
@@ -71,10 +71,7 @@ use super::{
     Error, NymConfig, Result, TunnelInterface, TunnelMetadata, TunnelSettings,
     tunnel::{
         self, AnyTunnelHandle, SelectedGateways, Tombstone,
-        wireguard::{
-            connected_tunnel,
-            connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
-        },
+        wireguard::connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
     },
 };
 #[cfg(target_os = "android")]
@@ -266,6 +263,13 @@ pub enum TunnelMonitorEvent {
         reply_tx: tokio::sync::oneshot::Sender<()>,
     },
 
+    /// The entry WireGuard handshake never completed, so the entry gateway is unreachable
+    /// from the current network. Nothing can be said about the exit gateway.
+    EntryHandshakeFailed {
+        /// Entry gateway whose handshake never completed.
+        entry_gateway_id: NodeIdentity,
+    },
+
     /// Connection has failed
     ConnectionFailed {
         /// Entry gateway used during the failed attempt.
@@ -373,24 +377,22 @@ async fn wait_for_handshake_outcome(
 }
 
 /// Poll the exit WireGuard peer's UAPI stats until the handshake completes or we time out.
-async fn wait_for_exit_handshake(
-    tunnel_handle: &connected_tunnel::TunnelHandle,
+async fn wait_for_handshake(
+    get_stats: impl FnMut() -> nym_wg_go::Result<nym_wg_go::wireguard_go::TunnelStats>,
     shutdown_token: &CancellationToken,
 ) -> HandshakeWaitOutcome {
-    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
-    const POLL_INTERVAL: Duration = Duration::from_millis(500);
-
-    tracing::debug!("Waiting for exit WireGuard handshake to complete");
+    /// How long the entry WireGuard peer gets to complete its handshake before the entry gateway is
+    /// declared unreachable. wireguard-go retransmits the initiation every 5s, so this covers the
+    /// first retransmission plus a generous round trip, while still failing a dead entry (e.g. its
+    /// WG port blackholed on this network) in a fraction of the exit handshake + metadata windows.
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(7);
+    const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
     let started = std::time::Instant::now();
 
-    let outcome = wait_for_handshake_outcome(
-        || tunnel_handle.get_exit_stats(),
-        shutdown_token,
-        HANDSHAKE_TIMEOUT,
-        POLL_INTERVAL,
-    )
-    .await;
+    let outcome =
+        wait_for_handshake_outcome(get_stats, shutdown_token, HANDSHAKE_TIMEOUT, POLL_INTERVAL)
+            .await;
 
     let elapsed = started.elapsed();
     match outcome {
@@ -759,7 +761,7 @@ impl TunnelMonitor {
             StartTunnelResult {
                 tunnel_interface,
                 tunnel_conn_data,
-                mut tunnel_handle,
+                tunnel_handle,
             },
             wg_tunnel_runtime,
             mixnet_client_token,
@@ -853,10 +855,42 @@ impl TunnelMonitor {
             tracing::warn!("Interface up reply timeout");
         }
 
-        // The firewall now allows traffic through the tunnel. Wait for the exit WG handshake.
+        // The firewall now allows traffic through the tunnel. First make sure the entry hop
+        // answers at all: an entry whose handshake never completes is dead from this network
+        // regardless of the exit, so it is failed fast and blamed alone instead of waiting out
+        // the exit handshake and metadata windows and blacklisting the exit first.
         let exit_handshake_completed = if let Some(wg_handle) = tunnel_handle.as_wireguard() {
-            wait_for_exit_handshake(wg_handle, &self.shutdown_token).await
-                == HandshakeWaitOutcome::Completed
+            tracing::debug!("Waiting for entry WireGuard handshake to complete");
+            let entry_outcome =
+                wait_for_handshake(|| wg_handle.get_entry_stats(), &self.shutdown_token).await;
+            match entry_outcome {
+                HandshakeWaitOutcome::Completed => {
+                    tracing::debug!("Waiting for exit WireGuard handshake to complete");
+                    wait_for_handshake(|| wg_handle.get_exit_stats(), &self.shutdown_token).await
+                        == HandshakeWaitOutcome::Completed
+                }
+                HandshakeWaitOutcome::TimedOut => {
+                    self.send_event(TunnelMonitorEvent::EntryHandshakeFailed {
+                        entry_gateway_id: selected_gateways.entry_gateway().identity(),
+                    });
+                    return Ok(Self::await_shutdown(
+                        wg_tunnel_runtime,
+                        None,
+                        tunnel_handle,
+                        shutdown_guard,
+                    )
+                    .await);
+                }
+                HandshakeWaitOutcome::Cancelled => {
+                    return Ok(Self::await_shutdown(
+                        wg_tunnel_runtime,
+                        None,
+                        tunnel_handle,
+                        shutdown_guard,
+                    )
+                    .await);
+                }
+            }
         } else {
             // Mixnet tunnels have no WireGuard handshake to observe, so failures are
             // never attributed to the entry gateway based on it.
@@ -1082,6 +1116,23 @@ impl TunnelMonitor {
             }
         }
 
+        Ok(Self::await_shutdown(
+            wg_tunnel_runtime,
+            Some(tunnel_connection_monitor_handle),
+            tunnel_handle,
+            shutdown_guard,
+        )
+        .await)
+    }
+
+    async fn await_shutdown(
+        wg_tunnel_runtime: Option<WgTunnelRuntime>,
+        tunnel_connection_monitor_handle: Option<
+            JoinHandle<Result<(), nym_connection_monitor::Error>>,
+        >,
+        mut tunnel_handle: AnyTunnelHandle,
+        shutdown_guard: DropGuard,
+    ) -> Tombstone {
         // Trigger cancellation since many other tasks depend on shutdown token
         drop(shutdown_guard);
 
@@ -1104,7 +1155,9 @@ impl TunnelMonitor {
             }
         }
 
-        if let Err(e) = tunnel_connection_monitor_handle.await {
+        if let Some(tunnel_connection_monitor_handle) = tunnel_connection_monitor_handle
+            && let Err(e) = tunnel_connection_monitor_handle.await
+        {
             tracing::error!("Tunnel connection monitor exited with error: {}", e);
         }
 
@@ -1121,7 +1174,7 @@ impl TunnelMonitor {
 
         tracing::info!("Tunnel monitor finished");
 
-        Ok(tun_devices)
+        tun_devices
     }
 
     async fn await_account_readiness_with_retry(&mut self) -> Result<(), Error> {

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "amnezia")]
 pub mod amnezia;
 pub mod netstack;
+pub mod stats;
 pub mod uapi;
 pub mod wireguard_go;
 

--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -17,9 +17,11 @@ use nym_windows::net::AddressFamily;
 
 use super::{
     Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result, uapi::UapiConfigBuilder,
+    wireguard_go::TunnelStats,
 };
 #[cfg(feature = "amnezia")]
 use crate::amnezia::AmneziaConfig;
+use crate::stats::StatsReader;
 
 /// Netstack interface configuration.
 pub struct InterfaceConfig {
@@ -91,6 +93,30 @@ pub struct Tunnel {
     tunnel_handle: i32,
 }
 
+/// Reads live peer stats of a netstack WireGuard tunnel via the UAPI GET interface.
+///
+/// Once the owning [`Tunnel`] is stopped the Go side no longer knows the handle and
+/// [`TunnelStatsReader::get_stats`] fails with [`Error::GetUapiConfig`].
+#[derive(Debug, Clone)]
+pub struct TunnelStatsReader {
+    tunnel_handle: i32,
+}
+
+impl StatsReader for TunnelStatsReader {
+    fn get_stats(&self) -> Result<TunnelStats> {
+        if self.tunnel_handle < 0 {
+            return Err(Error::TunnelStopped);
+        }
+        let raw = unsafe { wgNetGetConfig(self.tunnel_handle) };
+        if raw.is_null() {
+            return Err(Error::GetUapiConfig);
+        }
+        let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
+        unsafe { wgFreePtr(raw as *mut c_void) };
+        Ok(TunnelStats::parse(&s))
+    }
+}
+
 impl Tunnel {
     pub fn start(config: Config) -> Result<Self> {
         let interface_mtu = config.interface.mtu;
@@ -116,6 +142,13 @@ impl Tunnel {
             Ok(Self { tunnel_handle })
         } else {
             Err(Error::StartTunnel(tunnel_handle))
+        }
+    }
+
+    /// Create a stats reader that can query live peer stats without owning the tunnel.
+    pub fn stats_reader(&self) -> TunnelStatsReader {
+        TunnelStatsReader {
+            tunnel_handle: self.tunnel_handle,
         }
     }
 
@@ -403,7 +436,6 @@ unsafe extern "C" {
     unsafe fn wgNetSetConfig(net_tunnel_handle: i32, settings: *const c_char) -> i64;
 
     /// Returns the config of the WireGuard interface.
-    #[allow(unused)]
     unsafe fn wgNetGetConfig(net_tunnel_handle: i32) -> *const c_char;
 
     /// Start UDP connection proxy through the netstack tunnel.
@@ -456,7 +488,6 @@ unsafe extern "C" {
     unsafe fn wgNetRebindTunnelSocket(address_family: u16, interface_index: u32);
 
     /// Frees a pointer allocated by the go runtime - useful to free return value of wgGetConfig
-    #[allow(unused)]
     unsafe fn wgFreePtr(ptr: *mut c_void);
 }
 

--- a/nym-vpn-core/crates/nym-wg-go/src/stats.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/stats.rs
@@ -1,0 +1,8 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::{Result, wireguard_go::TunnelStats};
+
+pub trait StatsReader {
+    fn get_stats(&self) -> Result<TunnelStats>;
+}

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -24,6 +24,7 @@ use super::{
 };
 #[cfg(feature = "amnezia")]
 use crate::amnezia::AmneziaConfig;
+use crate::stats::StatsReader;
 
 /// Classic WireGuard interface configuration.
 pub struct InterfaceConfig {
@@ -404,14 +405,19 @@ impl TunnelStats {
     pub fn all_peers_connected(&self) -> bool {
         !self.peers.is_empty() && self.peers.iter().all(|p| p.has_completed_handshake())
     }
+
+    /// Parse the textual UAPI `get=1` response of a WireGuard device.
+    pub fn parse(response: &str) -> Self {
+        TunnelStatsReader::parse_tunnel_stats(response)
+    }
 }
 
 pub struct TunnelStatsReader {
     tunnel_handle: Arc<RwLock<i32>>, // Handle is shared between Tunnel and TunnelStatsReader
 }
 
-impl TunnelStatsReader {
-    pub fn get_stats(&self) -> Result<TunnelStats> {
+impl StatsReader for TunnelStatsReader {
+    fn get_stats(&self) -> Result<TunnelStats> {
         let handle = self
             .tunnel_handle
             .read()
@@ -425,10 +431,11 @@ impl TunnelStatsReader {
         }
         let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
         unsafe { wgFreePtr(raw as *mut c_void) };
-        tracing::trace!("TunnelStats: '{s}'");
         Ok(Self::parse_tunnel_stats(&s))
     }
+}
 
+impl TunnelStatsReader {
     fn parse_tunnel_stats(response: &str) -> TunnelStats {
         let mut listen_port: Option<u16> = None;
         let mut peers: Vec<PeerStats> = Vec::new();
@@ -621,5 +628,40 @@ impl WgLogLevel {
             x if x == WgLogLevel::Verbose as u32 => Some(WgLogLevel::Verbose),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UAPI_TWO_PEERS: &str = "private_key=00\n\
+listen_port=51820\n\
+public_key=1111111111111111111111111111111111111111111111111111111111111111\n\
+endpoint=1.2.3.4:51820\n\
+last_handshake_time_sec=1700000000\n\
+last_handshake_time_nsec=5\n\
+rx_bytes=10\n\
+tx_bytes=20\n\
+public_key=2222222222222222222222222222222222222222222222222222222222222222\n\
+endpoint=5.6.7.8:51820\n\
+last_handshake_time_sec=0\n\
+last_handshake_time_nsec=0\n\
+rx_bytes=0\n\
+tx_bytes=30\n\
+errno=0\n";
+
+    #[test]
+    fn parse_reports_per_peer_handshake_state() {
+        let stats = TunnelStats::parse(UAPI_TWO_PEERS);
+
+        assert_eq!(stats.listen_port, Some(51820));
+        assert_eq!(stats.peers.len(), 2);
+        assert!(stats.peers[0].has_completed_handshake());
+        assert!(
+            !stats.peers[1].has_completed_handshake(),
+            "a zero handshake timestamp means the peer never handshaked"
+        );
+        assert!(!stats.all_peers_connected());
     }
 }


### PR DESCRIPTION
* Fail fast on a dead entry gateway via the entry WG handshake

In Auto (Safest) mode the closest High-score gateway is always picked first. When that gateway's WireGuard UDP port is blackholed on the user's network (seen from China), every connect attempt stalls: the exit handshake window and the metadata check run out, the exit gets blacklisted first, and the entry is only blamed after a second strike. Three attempts take over a minute before the user sees an error.

Gate the connect on the entry peer's handshake instead. After the firewall opens, poll the entry WireGuard peer for up to 7s (one wireguard-go retransmission plus a slow round trip). If it never handshakes, emit `TunnelMonitorEvent::EntryHandshakeFailed`, blacklist the entry alone with the new `BlacklistReason::EntryHandshakeFailed`, and leave the exit eligible. A dead entry is now excluded after one ~7s strike instead of two ~20s ones.

To read entry peer stats, add `netstack::TunnelStatsReader` in nym-wg-go on top of the existing `wgNetGetConfig` export, expose `TunnelStats::parse`, and give the WireGuard `TunnelHandle` an `EntryStatsReader` that covers both the netstack and tun/tun layouts.

The failed strike still counts toward the reconnect cap so a network that blocks all UDP cannot cycle through the whole gateway list.

* Refactor

* Spread the closest pick

* Remove sensitive logging

* Don't start tunnel connection monitor on error

---------

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6310)
<!-- Reviewable:end -->
