### PR TITLE
Named-crate Rust coverage job and how-we-test note

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,0 +1,98 @@
+name: ci-coverage
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - "nym-vpn-core/crates/**"
+      - "nym-vpn-core/Cargo.toml"
+      - "nym-vpn-core/Cargo.lock"
+      - ".github/workflows/ci-coverage.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "nym-vpn-core/crates/**"
+      - "nym-vpn-core/Cargo.toml"
+      - "nym-vpn-core/Cargo.lock"
+      - ".github/workflows/ci-coverage.yml"
+  workflow_dispatch:
+
+env:
+  CI_TESTING: true
+  CARGO_TERM_COLOR: always
+  AGENT_ISSELFHOSTED: 1
+
+jobs:
+  build-wireguard-go-linux:
+    uses: ./.github/workflows/build-wireguard-go-linux.yml
+
+  coverage:
+    runs-on: arc-linux-latest
+    needs: build-wireguard-go-linux
+    permissions:
+      contents: read
+
+    steps:
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip jq
+
+      - name: Checkout repo
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Dotenv Action
+        uses: xom9ikk/dotenv@v2.4.0
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: llvm-tools-preview
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: wireguard-go_x86_64-linux-unknown
+          path: build/lib
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@d438492cf8a250514fa2d34b30bc3c0dc37c65ff # v2.87.8
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate code coverage
+        id: coverage
+        working-directory: nym-vpn-core
+        continue-on-error: true
+        run: |
+          cargo llvm-cov --locked --no-fail-fast --lcov --output-path lcov.info \
+            -p nym-vpn-lib \
+            -p nym-vpn-account-controller \
+            -p nym-vpn-api-client \
+            -p nym-gateway-directory \
+            -p nym-wg-metadata-client
+
+      - name: Coveralls upload
+        if: always() && hashFiles('nym-vpn-core/lcov.info') != ''
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: nym-vpn-core/lcov.info
+          format: lcov
+
+      - name: Skip Coveralls when lcov missing
+        if: always() && hashFiles('nym-vpn-core/lcov.info') == ''
+        run: echo '::notice::lcov.info missing; skipping Coveralls upload'
+
+      - name: Fail if llvm-cov failed
+        if: steps.coverage.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -26,6 +26,8 @@ env:
 
 jobs:
   build-wireguard-go-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-wireguard-go-linux.yml
 
   coverage:
@@ -39,27 +41,27 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip jq
 
       - name: Checkout repo
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Dotenv Action
-        uses: xom9ikk/dotenv@v2.4.0
+        uses: xom9ikk/dotenv@d0a56edc74279820eabbe34477511327e710d0de # v2.4.0
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # rust-toolchain
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: llvm-tools-preview
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "21.12"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wireguard-go_x86_64-linux-unknown
           path: build/lib

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -74,9 +74,8 @@ jobs:
       - name: Generate code coverage
         id: coverage
         working-directory: nym-vpn-core
-        continue-on-error: true
         run: |
-          cargo llvm-cov --locked --no-fail-fast --lcov --output-path lcov.info \
+          cargo llvm-cov --locked --ignore-run-fail --lcov --output-path lcov.info \
             -p nym-vpn-lib \
             -p nym-vpn-account-controller \
             -p nym-vpn-api-client \
@@ -84,17 +83,15 @@ jobs:
             -p nym-wg-metadata-client
 
       - name: Coveralls upload
-        if: always() && hashFiles('nym-vpn-core/lcov.info') != ''
+        if: hashFiles('nym-vpn-core/lcov.info') != ''
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: nym-vpn-core/lcov.info
           format: lcov
 
-      - name: Skip Coveralls when lcov missing
-        if: always() && hashFiles('nym-vpn-core/lcov.info') == ''
-        run: echo '::notice::lcov.info missing; skipping Coveralls upload'
-
-      - name: Fail if llvm-cov failed
-        if: steps.coverage.outcome == 'failure'
-        run: exit 1
+      - name: Fail if lcov missing
+        if: hashFiles('nym-vpn-core/lcov.info') == ''
+        run: |
+          echo '::error::lcov.info missing after llvm-cov'
+          exit 1

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -1,5 +1,17 @@
 # Nym VPN Core
 
+[![Coverage Status](https://coveralls.io/repos/github/nymtech/nym-vpn-client/badge.svg?branch=develop)](https://coveralls.io/github/nymtech/nym-vpn-client?branch=develop)
+
+## How we test
+
+Coveralls is line coverage for a named Rust crate set (`ci-coverage.yml`), not the whole client and not a product %.
+
+- Core: `cargo test --workspace` on Linux / macOS / Windows (`ci-nym-vpn-core-*.yml`). Privileged `nym-ifconfig` is a separate job.
+- Testharness: 18 live Debian cases against real `nym-vpnd` (`e2e-test.yml`, `crates/test`). That is the Linux tunnel primary-path suite, not the majority of tests in this repo.
+- Apple: XCTest under `nym-vpn-apple`.
+- Desktop UI: Playwright (`ci-playwright-tauri.yml`).
+- Mobile UI: Maestro Android / iOS.
+
 ## Clone Git repository
 
 Use the following command to clone repository with submodules:


### PR DESCRIPTION
## Description

- Coverage job runs llvm-cov on five core crates and uploads lcov to Coveralls.
- Report-only: no coverage floor. Missing lcov skips the upload with a notice.
- Core README badge plus a short test-layers note: testharness is 18 live Debian cases, not the majority of the suite.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6311)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated code coverage checks for core VPN components, with results uploaded to Coveralls.
  - Coverage checks now run for relevant pushes, pull requests, and manual requests.

- **Documentation**
  - Added a Coveralls coverage badge.
  - Documented the project’s test suites and clarified the scope of reported Rust code coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->