### PR TITLE
Fix cross-compilation issues when build on macOS host

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/net.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/net.rs
@@ -293,6 +293,7 @@ pub struct AllowedDns {
     non_tunnel_dns: Vec<Endpoint>,
 }
 
+#[cfg(not(target_os = "android"))]
 impl AllowedDns {
     /// Initialize `AllowedDns` with two separate sets of tunnel and non-tunnel DNS.
     /// No sanity checks are performed on the input.

--- a/nym-vpn-core/crates/nym-ipc/build.rs
+++ b/nym-vpn-core/crates/nym-ipc/build.rs
@@ -1,6 +1,8 @@
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
     // XPC protocol definition
-    if cfg!(target_os = "macos") {
+    if target_os == "macos" {
         // Rebuild if the ObjC file changes
         println!("cargo:rerun-if-changed=src/xpc/protocols.m");
 

--- a/nym-vpn-core/crates/nym-ipc/src/lib.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#![cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+
 mod auth_result;
 pub mod client;
 #[cfg(feature = "daemon")]


### PR DESCRIPTION


## Description

I have spotted a few issues when using rust-analyzer on workspace configured for Android and went ahead to fix them. These changes mostly improve experience developing for Android in a Rust workspace.

- Ensure that `impl AllowedDns` block isn't compiled on Android since the struct itself is not
- Use `CARGO_CFG_TARGET_OS` in `nym-ipc` build script to prevent running objc compiler when cross-compiling for Android on macOS
- Prevent `nym-ipc` from building on platforms different than Windows, Linux, macOS to prevent compilation errors due to missing `Transport`.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6315)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform-specific build handling across supported desktop platforms.
  - Fixed Android compatibility by excluding unsupported firewall functionality from Android builds.
  - Ensured macOS-specific IPC components are configured only for macOS targets.
  - The IPC component now builds only for Linux, Windows, and macOS; other platforms are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->