### PR TITLE
Fix Android `rustls-platform-verifier` panic.

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent gateway refresh storm when the API is unreachable (https://github.com/nymtech/nym-vpn-client/pull/6087)
 - [Windows] Wait for the VPN service to be running after install (https://github.com/nymtech/nym-vpn-client/pull/6245)
 - Avoid blocking daemon command loop when handling recents which may perform network calls (https://github.com/nymtech/nym-vpn-client/pull/6294)
+- [Android] Don't use `reqwest` HTTP client to avoid `rustls-platform-verifier` panic (https://github.com/nymtech/nym-vpn-client/pull/6316)
 
 
 ## [2026.12.3] - 2026-08-27

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5788,6 +5788,7 @@ name = "nym-file-updater"
 version = "2026.12.4-beta.1"
 dependencies = [
  "futures",
+ "nym-http-api-client",
  "reqwest 0.13.3",
  "tempfile",
  "thiserror 2.0.18",

--- a/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
@@ -137,7 +137,7 @@ impl Resolvconf {
             }
         };
 
-        PathBuf::from(format!("/proc/{}/", &pid)).exists()
+        PathBuf::from(format!("/proc/{}/", pid)).exists()
     }
 
     // Have to check whether dnsmasq has been configured to ignore

--- a/nym-vpn-core/crates/nym-file-updater/Cargo.toml
+++ b/nym-vpn-core/crates/nym-file-updater/Cargo.toml
@@ -18,6 +18,7 @@ wiremock = { workspace = true }
 
 [dependencies]
 futures = { workspace = true }
+nym-http-api-client = { workspace = true }
 reqwest = { workspace = true, features = ["rustls", "stream"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "sync", "io-util", "macros"] }

--- a/nym-vpn-core/crates/nym-file-updater/src/updater.rs
+++ b/nym-vpn-core/crates/nym-file-updater/src/updater.rs
@@ -129,7 +129,7 @@ pub struct FileUpdater {
 impl FileUpdater {
     /// Create a new `FileUpdater` with a default HTTP client, returning the updater and a handle.
     pub fn new() -> Result<(Self, FileUpdaterHandle), FileUpdaterError> {
-        let http_client = reqwest::Client::builder()
+        let http_client = nym_http_api_client::registry::default_builder()
             .connect_timeout(Duration::from_secs(10))
             .build()
             .map_err(|error| FileUpdaterError::BuildHttpClient { error })?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
@@ -72,10 +72,6 @@ impl HttpRpc {
         let proxy = reqwest::Proxy::all(&socks5_url)
             .map_err(|e| HttpRpcError::Internal(format!("Failed to create proxy: {}", e)))?;
 
-        // Use the registered default builder (rather than `reqwest::Client::builder()`
-        // directly) so platform-specific TLS backend configuration - such as the
-        // webpki-preconfigured backend registered on Android to avoid depending on
-        // `rustls-platform-verifier`'s JNI initialization - applies to this client too.
         let http_client = nym_http_api_client::registry::default_builder()
             .proxy(proxy)
             .timeout(self.config.request_timeout)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
@@ -72,7 +72,11 @@ impl HttpRpc {
         let proxy = reqwest::Proxy::all(&socks5_url)
             .map_err(|e| HttpRpcError::Internal(format!("Failed to create proxy: {}", e)))?;
 
-        let http_client = Client::builder()
+        // Use the registered default builder (rather than `reqwest::Client::builder()`
+        // directly) so platform-specific TLS backend configuration - such as the
+        // webpki-preconfigured backend registered on Android to avoid depending on
+        // `rustls-platform-verifier`'s JNI initialization - applies to this client too.
+        let http_client = nym_http_api_client::registry::default_builder()
             .proxy(proxy)
             .timeout(self.config.request_timeout)
             .build()

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -66,11 +66,7 @@ impl LazyMetadataClient {
         sent_data: TunUpSendData,
     ) -> Result<Self> {
         let mut interface_name = None;
-        // Start from the registered default builder (rather than `ReqwestClientBuilder::new()`)
-        // so platform-specific TLS backend configuration - such as the webpki-preconfigured
-        // backend registered on Android to avoid depending on `rustls-platform-verifier`'s JNI
-        // initialization - applies here too, even though `.with_reqwest_builder()` below
-        // otherwise bypasses it.
+
         let reqwest_builder = nym_http_api_client::registry::default_builder();
         let reqwest_builder = match sent_data.data_type {
             TunUpSendDataType::InterfaceName(interface) => {

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -8,7 +8,6 @@ use std::{
 
 use nym_credentials_interface::CredentialSpendingData;
 use nym_gateway_directory::NodeIdentity;
-use nym_http_api_client::ReqwestClientBuilder;
 use nym_wireguard_private_metadata_client::WireguardMetadataApiClient;
 use nym_wireguard_private_metadata_shared::{AvailableBandwidth, Version, v1, v2};
 use tokio::sync::{OnceCell, oneshot};
@@ -67,7 +66,12 @@ impl LazyMetadataClient {
         sent_data: TunUpSendData,
     ) -> Result<Self> {
         let mut interface_name = None;
-        let reqwest_builder = ReqwestClientBuilder::new();
+        // Start from the registered default builder (rather than `ReqwestClientBuilder::new()`)
+        // so platform-specific TLS backend configuration - such as the webpki-preconfigured
+        // backend registered on Android to avoid depending on `rustls-platform-verifier`'s JNI
+        // initialization - applies here too, even though `.with_reqwest_builder()` below
+        // otherwise bypasses it.
+        let reqwest_builder = nym_http_api_client::registry::default_builder();
         let reqwest_builder = match sent_data.data_type {
             TunUpSendDataType::InterfaceName(interface) => {
                 #[cfg(any(target_os = "linux", target_os = "ios"))]


### PR DESCRIPTION
On Android we should always the HTTP client from the `nym_http_api_client` crate instead of directly from `reqwest`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6316)
<!-- Reviewable:end -->
