### PR TITLE
Fix Android `rustls-platform-verifier` panic. (#6316)

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Windows] Wait for the VPN service to be running after install (https://github.com/nymtech/nym-vpn-client/pull/6245)
 - Avoid blocking daemon command loop when handling recents which may perform network calls (https://github.com/nymtech/nym-vpn-client/pull/6294)
 - Remove failed pending requests before creating new ones (https://github.com/nymtech/nym-vpn-client/pull/6295)
+- [Android] Don't use `reqwest` HTTP client to avoid `rustls-platform-verifier` panic (https://github.com/nymtech/nym-vpn-client/pull/6316)
 
 ## [2026.12.3] - 2026-08-27
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -6043,6 +6043,7 @@ name = "nym-file-updater"
 version = "2026.13.0-beta.1"
 dependencies = [
  "futures",
+ "nym-http-api-client",
  "reqwest 0.13.4",
  "tempfile",
  "thiserror 2.0.20",

--- a/nym-vpn-core/crates/nym-file-updater/Cargo.toml
+++ b/nym-vpn-core/crates/nym-file-updater/Cargo.toml
@@ -18,6 +18,7 @@ wiremock = { workspace = true }
 
 [dependencies]
 futures = { workspace = true }
+nym-http-api-client = { workspace = true }
 reqwest = { workspace = true, features = ["rustls", "stream"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "sync", "io-util", "macros"] }

--- a/nym-vpn-core/crates/nym-file-updater/src/updater.rs
+++ b/nym-vpn-core/crates/nym-file-updater/src/updater.rs
@@ -129,7 +129,7 @@ pub struct FileUpdater {
 impl FileUpdater {
     /// Create a new `FileUpdater` with a default HTTP client, returning the updater and a handle.
     pub fn new() -> Result<(Self, FileUpdaterHandle), FileUpdaterError> {
-        let http_client = reqwest::Client::builder()
+        let http_client = nym_http_api_client::registry::default_builder()
             .connect_timeout(Duration::from_secs(10))
             .build()
             .map_err(|error| FileUpdaterError::BuildHttpClient { error })?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/http_rpc.rs
@@ -72,7 +72,7 @@ impl HttpRpc {
         let proxy = reqwest::Proxy::all(&socks5_url)
             .map_err(|e| HttpRpcError::Internal(format!("Failed to create proxy: {}", e)))?;
 
-        let http_client = Client::builder()
+        let http_client = nym_http_api_client::registry::default_builder()
             .proxy(proxy)
             .timeout(self.config.request_timeout)
             .build()

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -8,7 +8,6 @@ use std::{
 
 use nym_credentials_interface::CredentialSpendingData;
 use nym_gateway_directory::NodeIdentity;
-use nym_http_api_client::ReqwestClientBuilder;
 use nym_wireguard_private_metadata_client::WireguardMetadataApiClient;
 use nym_wireguard_private_metadata_shared::{AvailableBandwidth, Version, v1, v2};
 use tokio::sync::{OnceCell, oneshot};
@@ -67,7 +66,8 @@ impl LazyMetadataClient {
         sent_data: TunUpSendData,
     ) -> Result<Self> {
         let mut interface_name = None;
-        let reqwest_builder = ReqwestClientBuilder::new();
+
+        let reqwest_builder = nym_http_api_client::registry::default_builder();
         let reqwest_builder = match sent_data.data_type {
             TunUpSendDataType::InterfaceName(interface) => {
                 #[cfg(any(target_os = "linux", target_os = "ios"))]


### PR DESCRIPTION
On Android we should always the HTTP client from the `nym_http_api_client` crate instead of directly from `reqwest`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6317)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an Android issue that could cause the app to crash during network operations.
  - Improved reliability for file updates, VPN connectivity, and network metadata requests by using consistent platform-compatible connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->