### PR TITLE
[Android] Add profiles screen to settings

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profiles: UI and logic (https://github.com/nymtech/nym-vpn-client/pull/6144)
 - Set geo location for android command sender (https://github.com/nymtech/nym-vpn-client/pull/6144)
 - Log prior process exit reasons on startup (https://github.com/nymtech/nym-vpn-client/pull/6236)
+- Add Profiles screen to Settings (https://github.com/nymtech/nym-vpn-client/pull/6319)
 
 ### Changed
 - Remove score placeholder. Update animation (https://github.com/nymtech/nym-vpn-client/pull/6231)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/MainActivity.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/MainActivity.kt
@@ -78,6 +78,7 @@ import net.nymtech.nymvpn.ui.screens.settings.geoexclusion.GeoExclusionScreen
 import net.nymtech.nymvpn.ui.screens.settings.geoexclusion.setup.SetupScreen
 import net.nymtech.nymvpn.ui.screens.settings.notifications.NotificationsScreen
 import net.nymtech.nymvpn.ui.screens.settings.privacy.PrivacyScreen
+import net.nymtech.nymvpn.ui.screens.settings.profiles.ProfilesScreen
 import net.nymtech.nymvpn.ui.screens.settings.support.SupportScreen
 import net.nymtech.nymvpn.ui.screens.settings.tuning.MixnetTuningScreen
 import net.nymtech.nymvpn.ui.screens.settings.tunneling.SplitTunnelingScreen
@@ -370,6 +371,7 @@ class MainActivity : AppCompatActivity() {
 								composable<Route.Notifications> { NotificationsScreen(appState) }
 								composable<Route.GeoExclusion> { GeoExclusionScreen(appState) }
 								composable<Route.Setup> { SetupScreen(appState) }
+								composable<Route.Profiles> { ProfilesScreen(appState, appViewModel) }
 							}
 						}
 					}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/Route.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/Route.kt
@@ -96,4 +96,7 @@ sealed class Route {
 
 	@Serializable
 	data object Setup : Route()
+
+	@Serializable
+	data object Profiles : Route()
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/navigation/NavBar.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/navigation/NavBar.kt
@@ -229,6 +229,10 @@ fun NavBar(
 				titleRes = R.string.setup_instructions_title,
 				onBack = { navController.safePopBackStack() },
 			)
+			route.startsWith(Route.Profiles::class.qualifiedName!!) -> NavBarState.WithBack(
+				titleRes = R.string.profiles_title,
+				onBack = { navController.safePopBackStack() },
+			)
 
 			else -> NavBarState.Hidden
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
@@ -95,9 +95,10 @@ internal fun NodeSection(
 @Composable
 private fun ServerRow(node: ServerNode, isClickable: Boolean, onServerClick: () -> Unit, onInfoClick: () -> Unit, modifier: Modifier = Modifier) {
 	val indication = if (isClickable) ripple() else null
-	val showDetails = node.location != null
+	val showDetails = node.id.isNotEmpty()
+	val showLocation = node.location != null
 	val locationAlpha by animateFloatAsState(
-		targetValue = if (showDetails) 1f else 0f,
+		targetValue = if (showLocation) 1f else 0f,
 		animationSpec = tween(350),
 		label = "locationAlpha",
 	)
@@ -105,7 +106,7 @@ private fun ServerRow(node: ServerNode, isClickable: Boolean, onServerClick: () 
 		MaterialTheme.typography.bodySmall.lineHeight.toDp()
 	}
 	val nameOffset by animateDpAsState(
-		targetValue = if (showDetails) 0.dp else (locationLineHeight + 2.dp) / 2,
+		targetValue = if (showLocation) 0.dp else (locationLineHeight + 2.dp) / 2,
 		animationSpec = tween(350),
 		label = "nameOffset",
 	)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/profiles/ProfilesPanel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/profiles/ProfilesPanel.kt
@@ -93,7 +93,7 @@ private fun ProfilesPanelContent(selected: Profile?, onSelect: (Profile) -> Unit
 }
 
 @Composable
-private fun ProfileRow(profile: Profile, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+fun ProfileRow(profile: Profile, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
 	val interactionSource = remember { MutableInteractionSource() }
 	Row(
 		modifier = modifier

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsActions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsActions.kt
@@ -29,4 +29,5 @@ data class SettingsActions(
 	val onSystemTrayEnable: (enabled: Boolean) -> Unit = {},
 	val onMixnetTuningClick: () -> Unit = {},
 	val onGeoExclusionClick: () -> Unit = {},
+	val onProfilesClick: () -> Unit = {},
 )

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
@@ -218,6 +218,9 @@ fun SettingsScreen(appUiState: AppUiState, appViewModel: AppViewModel, showVpnSe
 			onGeoExclusionClick = {
 				navController.navigate(Route.GeoExclusion)
 			},
+			onProfilesClick = {
+				navController.navigate(Route.Profiles)
+			},
 		),
 	)
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/components/VpnSettingsSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/components/VpnSettingsSection.kt
@@ -144,7 +144,7 @@ fun VpnSettingsSection(values: SettingsValues, actions: SettingsActions) {
 					},
 					description = {
 						Text(
-							stringResource(R.string.settings_geo_exclusion_desciption),
+							stringResource(R.string.settings_geo_exclusion_description),
 							style = MaterialTheme.typography.bodySmall,
 							color = MaterialTheme.colorScheme.onBackground,
 						)
@@ -210,6 +210,30 @@ fun VpnSettingsSection(values: SettingsValues, actions: SettingsActions) {
 						SettingsTitle(stringResource(R.string.settings_mixnet_tuning_title))
 					},
 					onClick = actions.onMixnetTuningClick,
+				),
+			)
+			add(
+				SelectionItem(
+					leading = {
+						SettingsIcon(
+							ImageVector.vectorResource(R.drawable.ic_profiles),
+							stringResource(R.string.settings_profiles_title),
+						)
+					},
+					trailing = {
+						SettingsArrowIcon()
+					},
+					description = {
+						Text(
+							stringResource(R.string.settings_profiles_description),
+							style = MaterialTheme.typography.bodySmall,
+							color = MaterialTheme.colorScheme.onBackground,
+						)
+					},
+					title = {
+						SettingsTitle(stringResource(R.string.settings_profiles_title))
+					},
+					onClick = actions.onProfilesClick,
 				),
 			)
 			add(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/profiles/ProfilesScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/profiles/ProfilesScreen.kt
@@ -1,0 +1,114 @@
+package net.nymtech.nymvpn.ui.screens.settings.profiles
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import net.nymtech.nymvpn.R
+import net.nymtech.nymvpn.ui.AppUiState
+import net.nymtech.nymvpn.ui.AppViewModel
+import net.nymtech.nymvpn.ui.screens.main.profiles.Profile
+import net.nymtech.nymvpn.ui.screens.main.profiles.ProfileRow
+import net.nymtech.nymvpn.ui.theme.NymVPNTheme
+import net.nymtech.nymvpn.ui.theme.Theme
+import net.nymtech.nymvpn.util.extensions.openWebUrl
+import net.nymtech.nymvpn.util.extensions.scaledHeight
+import net.nymtech.nymvpn.util.extensions.scaledWidth
+import kotlin.enums.enumEntries
+
+@Composable
+fun ProfilesScreen(appUiState: AppUiState, appViewModel: AppViewModel) {
+	ProfilesScreen(appUiState.currentProfile, appViewModel::onProfileSelected)
+}
+
+@Composable
+fun ProfilesScreen(selected: Profile?, onSelect: (Profile) -> Unit) {
+	val context = LocalContext.current
+	val interactionSource = remember { MutableInteractionSource() }
+
+	Column(
+		horizontalAlignment = Alignment.Start,
+		verticalArrangement = Arrangement.spacedBy(18.dp, Alignment.Top),
+		modifier = Modifier
+			.verticalScroll(rememberScrollState())
+			.fillMaxSize()
+			.padding(vertical = 18.dp.scaledHeight())
+			.padding(horizontal = 18.dp.scaledWidth()),
+	) {
+		Text(
+			text = stringResource(R.string.profiles_description),
+			style = MaterialTheme.typography.bodyMedium.copy(MaterialTheme.colorScheme.onBackground),
+		)
+		Column(
+			modifier = Modifier.fillMaxWidth()
+				.background(MaterialTheme.colorScheme.surfaceVariant),
+		) {
+			enumEntries<Profile>().forEach { profile ->
+				ProfileRow(
+					profile = profile,
+					selected = profile == selected,
+					onClick = { onSelect(profile) },
+					modifier = Modifier.fillMaxWidth(),
+				)
+			}
+		}
+		Row(
+			horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
+			modifier = Modifier
+				.fillMaxWidth()
+				.clickable(
+					interactionSource = interactionSource,
+					indication = null,
+				) {
+					context.openWebUrl(context.getString(R.string.profiles_learn_more_link))
+				},
+		) {
+			Text(
+				text = stringResource(R.string.profiles_learn_more_text),
+				color = MaterialTheme.colorScheme.onPrimaryContainer,
+				style = MaterialTheme.typography.bodyMedium.copy(
+					textDecoration = TextDecoration.Underline,
+				),
+			)
+			Icon(
+				Icons.AutoMirrored.Outlined.OpenInNew,
+				stringResource(R.string.go),
+				Modifier
+					.size(16.dp)
+					.align(Alignment.CenterVertically),
+				tint = MaterialTheme.colorScheme.onPrimaryContainer,
+			)
+		}
+	}
+}
+
+@Composable
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+internal fun PreviewProfilesScreen() {
+	NymVPNTheme(Theme.default()) {
+		ProfilesScreen(null, {})
+	}
+}

--- a/nym-vpn-android/app/src/main/res/values-ar/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-ar/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">سجلات &amp; البيانات</string>
 	<string name="settings_legal_title">قانوني</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">قفل الشاشة مطلوب لاستخدام الاختصار.</string>
 	<string name="shortcut_title">تأكيد الإجراء</string>

--- a/nym-vpn-android/app/src/main/res/values-bn-rBD/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-bn-rBD/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">Logs &amp; data</string>
 	<string name="settings_legal_title">Legal</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">শর্টকাট ব্যবহার করার জন্য স্ক্রিন লক করা আবশ্যক।</string>
 	<string name="shortcut_title">নিশ্চিত করুন</string>

--- a/nym-vpn-android/app/src/main/res/values-de/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-de/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">Logs &amp; Daten</string>
 	<string name="settings_legal_title">Rechtliches</string>
 	<string name="settings_geo_exclusion_title">Geografische Ausschlüsse</string>
-	<string name="settings_geo_exclusion_desciption">Bestimmte IP-Bereiche stellen eine direkte Verbindung her</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Bildschirmsperre erforderlich, um Verknüpfungen zu verwenden.</string>
 	<string name="shortcut_title">Vorgang bestätigen</string>

--- a/nym-vpn-android/app/src/main/res/values-es/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-es/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">Registros &amp; datos</string>
 	<string name="settings_legal_title">Legal</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Bloqueo de pantalla necesario para usar accesos directos.</string>
 	<string name="shortcut_title">Confirmar acción</string>

--- a/nym-vpn-android/app/src/main/res/values-fa/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-fa/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">لاگ‌ها &amp; و داده‌ها</string>
 	<string name="settings_legal_title">قوانین و مقررات</string>
 	<string name="settings_geo_exclusion_title">استثنای جغرافیایی</string>
-	<string name="settings_geo_exclusion_desciption">به بازه‌های مشخص IP مستقیماً متصل می‌شوند</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">برای استفاده از میانبرها ایجاد قفل صفحه لازم است.</string>
 	<string name="shortcut_title">تأیید عملیات</string>

--- a/nym-vpn-android/app/src/main/res/values-fr/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-fr/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">Logs &amp; données</string>
 	<string name="settings_legal_title">Mentions légales</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Le verrouillage de l\'écran est requis pour utiliser les raccourcis.</string>
 	<string name="shortcut_title">Confirmer l\'action</string>

--- a/nym-vpn-android/app/src/main/res/values-hi/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-hi/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">लॉग &amp; डेटा</string>
 	<string name="settings_legal_title">कानूनी</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">शॉर्टकट का उपयोग करने के लिए स्क्रीन लॉक आवश्यक है।</string>
 	<string name="shortcut_title">कन्फ़र्म करें</string>

--- a/nym-vpn-android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-pt-rBR/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">Registros &amp; dados</string>
 	<string name="settings_legal_title">Jurídico</string>
 	<string name="settings_geo_exclusion_title">Exclusão geográfica</string>
-	<string name="settings_geo_exclusion_desciption">Faixas de IP específicas conectam diretamente</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Bloqueio de tela necessário para usar atalhos.</string>
 	<string name="shortcut_title">Confirmar ação</string>

--- a/nym-vpn-android/app/src/main/res/values-ru/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-ru/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">Логи &amp; данные</string>
 	<string name="settings_legal_title">Юридическая информация</string>
 	<string name="settings_geo_exclusion_title">Исключение по геолокации</string>
-	<string name="settings_geo_exclusion_desciption">Определённые диапазоны IP подключаются напрямую</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Для использования горячих клавиш требуется блокировка экрана.</string>
 	<string name="shortcut_title">Подтвердите действие</string>

--- a/nym-vpn-android/app/src/main/res/values-tr/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-tr/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">Günlükler ve veri</string>
 	<string name="settings_legal_title">Yasal</string>
 	<string name="settings_geo_exclusion_title">Bölgesel hariç tutma</string>
-	<string name="settings_geo_exclusion_desciption">Belirli IP aralıkları doğrudan bağlanır</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Kısayolları kullanabilmek için önce cihazınızın ekran kilidini açmanız gerekiyor.</string>
 	<string name="shortcut_title">İşlemi onaylayın</string>

--- a/nym-vpn-android/app/src/main/res/values-uk/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-uk/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">Журнали &amp; та дані</string>
 	<string name="settings_legal_title">Правові</string>
 	<string name="settings_geo_exclusion_title">Географічне виключення</string>
-	<string name="settings_geo_exclusion_desciption">Певні діапазони IP-адрес підключаються безпосередньо</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Для використання ярликів необхідне блокування екрану.</string>
 	<string name="shortcut_title">Підтвердити дію</string>

--- a/nym-vpn-android/app/src/main/res/values-vi-rVN/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-vi-rVN/strings.xml
@@ -230,7 +230,7 @@
 	<string name="settings_logs_title">Nhật ký &amp; dữ liệu</string>
 	<string name="settings_legal_title">Pháp lý</string>
 	<string name="settings_geo_exclusion_title">Loại Trừ Địa Lý</string>
-	<string name="settings_geo_exclusion_desciption">Các dải IP cụ thể kết nối trực tiếp</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Cần khóa màn hình để sử dụng các phím tắt.</string>
 	<string name="shortcut_title">Xác nhận hành động</string>

--- a/nym-vpn-android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values-zh-rCN/strings.xml
@@ -232,7 +232,7 @@
 	<string name="settings_logs_title">日志和数据</string>
 	<string name="settings_legal_title">法律</string>
 	<string name="settings_geo_exclusion_title">地理隧道分流</string>
-	<string name="settings_geo_exclusion_desciption">特定范围的 IP 地址不会经过 VPN 隧道</string>
+
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">需要先锁屏才能开启应用快捷方式。</string>
 	<string name="shortcut_title">确认</string>

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -279,7 +279,9 @@
 	<string name="settings_logs_title">Logs &amp; data</string>
 	<string name="settings_legal_title">Legal</string>
 	<string name="settings_geo_exclusion_title">Geo Exclusion</string>
-	<string name="settings_geo_exclusion_desciption">Specific IP ranges connect directly</string>
+	<string name="settings_geo_exclusion_description">Specific IP ranges connect directly</string>
+	<string name="settings_profiles_title">Connection profiles</string>
+	<string name="settings_profiles_description">Let us help you connect</string>
 	<!-- Shortcuts activity -->
 	<string name="shortcuts_info_message">Screen lock required to use shortcuts.</string>
 	<string name="shortcut_title">Confirm action</string>
@@ -680,4 +682,7 @@
 	<string name="profiles_most_private_description">Metadata resistance and mixnet tuning</string>
 	<string name="profiles_fastest_title">Fastest</string>
 	<string name="profiles_fastest_description">Chooses the closest, best for streaming</string>
+	<string name="profiles_description">Profiles are connection templates, that we baked in for you to start experimenting with the privacy - speed experience that’s best suits your needs.</string>
+	<string name="profiles_learn_more_text">Learn more about profiles here</string>
+	<string name="profiles_learn_more_link"></string>
 </resources>

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -79,7 +79,7 @@ class VpnTunController(private val service: VpnService) {
 			throw e
 		} catch (t: Throwable) {
 			Timber.tag(TAG).e(t, "TunnelConfigureFailed")
-			-1
+			throw VpnException.InternalException("Failed to configure VPN tunnel. Reason: $t")
 		}
 	}
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Add Profiles to Settings screen.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
<img width="360" height="808" alt="Screenshot_20260909_163002" src="https://github.com/user-attachments/assets/eeb956fc-14af-4565-a0c8-64804c175c04" />
<img width="360" height="808" alt="Screenshot_20260909_163007" src="https://github.com/user-attachments/assets/cc72d730-12e4-4ef5-bc83-536ac148cd03" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6319)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Profiles screen under Settings for viewing and selecting connection profiles.
  - Added profile descriptions, a “Learn more” link, and navigation with a back button.

- **Bug Fixes**
  - Corrected the Geo Exclusion description label.
  - Improved server information display when location or details are unavailable.
  - Tunnel configuration now reports failures when required VPN exclusions cannot be applied.

- **Documentation**
  - Updated the upcoming release changelog with connection and tunnel error-handling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->