### PR TITLE
CI: fix santa menu on iOS (vanil-noir)

### DIFF
--- a/.github/workflows/build-nym-vpn-app-ios.yml
+++ b/.github/workflows/build-nym-vpn-app-ios.yml
@@ -114,11 +114,18 @@ jobs:
           echo "🧩 Selected mode (raw): $sel"
           echo "🧩 Normalized mode: $mode"
 
+          # Santa's-menu QA code is gated behind `#if SANTA`. Compile it in for
+          # `qa` only; left OUT of `pr` and `ship` so it is physically absent
+          # from App Store binaries.
+          if [[ "$mode" == "qa" ]]; then santa=1; else santa=0; fi
+
           # Export environment variables for later steps
           echo "RELEASE_TYPE=$mode" >> "$GITHUB_ENV"
+          echo "NYM_SANTA=$santa" >> "$GITHUB_ENV"
 
           echo "✅ Environment successfully configured:"
           echo "   RELEASE_TYPE=$mode"
+          echo "   NYM_SANTA=$santa"
           echo "--------------------------------------------------"
 
       - name: Show selected release type


### PR DESCRIPTION
## Description

Santa menu has not been activated due to missing `NYM_SANTA=1`

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6323)
<!-- Reviewable:end -->
