### PR TITLE
feat(i18n): add zh-TW (Traditional Chinese) locale across apps (#6305)

### DIFF
--- a/.github/workflows/crowdin-android-download.yml
+++ b/.github/workflows/crowdin-android-download.yml
@@ -24,7 +24,7 @@ jobs:
           upload_translations: false
           download_translations: true
           config: "crowdin-configs/android.yml"
-          command_args: "-l ar -l bn -l de -l es-ES -l fa -l fr -l hi -l pt-BR -l ru -l tr -l uk -l vi -l zh-CN"
+          command_args: "-l ar -l bn -l de -l es-ES -l fa -l fr -l hi -l pt-BR -l ru -l tr -l uk -l vi -l zh-CN -l zh-TW"
           localization_branch_name: "l10n_crowdin_android_${{ github.ref_name }}"
           create_pull_request: true
           pull_request_title: "Localization: Update Android Translations (${{ github.ref_name }})"

--- a/crowdin-configs/android.yml
+++ b/crowdin-configs/android.yml
@@ -18,6 +18,7 @@ languages_mapping:
     uk: uk
     vi: vi-rVN
     zh-CN: zh-rCN
+    zh-TW: zh-rTW
   # Mapping for Fastlane / Google Play Store Metadata
   locale: &play-locale
     ar: ar
@@ -34,6 +35,7 @@ languages_mapping:
     uk: uk
     vi: vi
     zh-CN: zh-CN
+    zh-TW: zh-TW
 files:
   - source: "nym-vpn-android/app/src/main/res/values/strings.xml"
     translation: "nym-vpn-android/app/src/main/res/values-%android_code%/strings.xml"

--- a/crowdin-configs/linux-windows.yml
+++ b/crowdin-configs/linux-windows.yml
@@ -7,3 +7,9 @@ preserve_hierarchy: true
 files:
   - source: "nym-vpn-app/src/i18n/en/*.json"
     translation: "nym-vpn-app/src/i18n/%two_letters_code%/%original_file_name%"
+    # Traditional Chinese is Crowdin language `zh-TW`; keep it as `zh-TW` so
+    # %two_letters_code% doesn't collapse it to `zh` and collide with Simplified
+    # in src/i18n/zh/.
+    languages_mapping:
+      two_letters_code:
+        zh-TW: zh-TW

--- a/nym-vpn-android/buildSrc/src/main/kotlin/Extensions.kt
+++ b/nym-vpn-android/buildSrc/src/main/kotlin/Extensions.kt
@@ -54,6 +54,7 @@ fun Project.languageList(): List<String> {
 		"tr",      // Turkish
 		"uk",      // Ukrainian
 		"vi-rVN",  // Vietnamese
-		"zh-rCN"   // Chinese (Simplified)
+		"zh-rCN",  // Chinese (Simplified)
+		"zh-rTW"   // Chinese (Traditional)
 	).sorted()
 }

--- a/nym-vpn-app/src/i18n/config.ts
+++ b/nym-vpn-app/src/i18n/config.ts
@@ -40,7 +40,8 @@ export const languages = [
   { code: 'tr', name: 'Türkçe' },
   { code: 'uk', name: 'Українська' },
   { code: 'vi', name: 'Tiếng Việt' },
-  { code: 'zh', name: '中文' },
+  { code: 'zh', name: '简体中文' },
+  { code: 'zh-TW', name: '繁體中文' },
 
   // { code: 'cs', name: 'Čeština (Czech)' },
   // { code: 'hu', name: 'Magyar (Hungarian)' },

--- a/nym-vpn-app/src/i18n/utils.ts
+++ b/nym-vpn-app/src/i18n/utils.ts
@@ -6,14 +6,18 @@ import { LngTag } from './types';
  * supported language tag. Falls back to 'en' if no match is found.
  */
 export function matchSupportedLocale(osLocale: string): LngTag {
-  // Try exact match first (e.g. "en" → "en")
   const lower = osLocale.toLowerCase();
-  if ((supportedLngs as readonly string[]).includes(lower)) {
-    return lower as LngTag;
+
+  // Exact match, case-insensitive (e.g. "zh-TW" → "zh-TW", "EN" → "en")
+  const exact = (supportedLngs as readonly string[]).find(
+    (code) => code.toLowerCase() === lower,
+  );
+  if (exact) {
+    return exact as LngTag;
   }
 
-  // Try matching just the primary language subtag (e.g. "en-US" → "en", "zh-Hans-CN" → "zh")
-  const lang = osLocale.split(/[-_]/)[0].toLowerCase();
+  // Fall back to the primary language subtag (e.g. "en-US" → "en", "zh-HK" → "zh")
+  const lang = lower.split(/[-_]/)[0];
   if ((supportedLngs as readonly string[]).includes(lang)) {
     return lang as LngTag;
   }

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -32,6 +32,7 @@ import 'dayjs/locale/tr';
 import 'dayjs/locale/uk';
 import 'dayjs/locale/vi';
 import 'dayjs/locale/zh';
+import 'dayjs/locale/zh-tw';
 
 console.log('env', window._APP);
 

--- a/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
+++ b/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
@@ -756,6 +756,7 @@
 				fr,
 				ar,
 				"zh-Hans",
+				"zh-Hant",
 				de,
 				hi,
 				fa,


### PR DESCRIPTION
* feat(i18n): add zh-TW (Traditional Chinese) locale across apps

Register zh-TW in the Tauri, Android and Apple clients and wire the Crowdin configs so translations sync into each app. Locales fall back to English until the Crowdin download runs.

* fix(i18n): resolve Traditional Chinese OS locales to zh-TW

Peer-review fixes: case-insensitive + script-aware locale matching so zh-TW/zh-Hant/zh-HK/zh-MO select Traditional; import dayjs zh-tw; relabel Simplified as 简体中文.

* refactor(i18n): represent Traditional Chinese as zh-Hant, not zh-TW

Script code zh-Hant is region-neutral (Taiwan, Hong Kong, Macau); zh-TW is Taiwan-only. Crowdin language stays zh-TW, mapped per-platform: Tauri zh-Hant (+dayjs zh-tw alias), Android languageList zh-Hant + res folder b+zh+Hant + script-aware picker label, desktop Crowdin mapping zh-TW->zh-Hant. Apple already zh-Hant.

* refactor(i18n): revert to region-form Traditional Chinese (zh-TW/zh-rTW)

Mirror Simplified's per-platform form: Tauri zh-TW, Android zh-rTW (like zh-rCN), Apple keeps zh-Hant (like zh-Hans). Drops the LocaleUtil/picker/dayjs/script-matcher machinery the script form needed; keeps the case-insensitive OS-locale match. Auto-detect is Taiwan-only on Tauri/Android; region-neutral (b+zh+Hant) script form deferred.

(cherry picked from commit 6c1564e53075fdc06d4da5fb2448793b98c3daef)

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6326)
<!-- Reviewable:end -->
