### PR TITLE
feat(i18n): add Italian and Indonesian locales across apps

### DIFF
--- a/.github/workflows/crowdin-android-download.yml
+++ b/.github/workflows/crowdin-android-download.yml
@@ -24,7 +24,7 @@ jobs:
           upload_translations: false
           download_translations: true
           config: "crowdin-configs/android.yml"
-          command_args: "-l ar -l bn -l de -l es-ES -l fa -l fr -l hi -l pt-BR -l ru -l tr -l uk -l vi -l zh-CN -l zh-TW"
+          command_args: "-l ar -l bn -l de -l es-ES -l fa -l fr -l hi -l pt-BR -l ru -l tr -l uk -l vi -l zh-CN -l zh-TW -l it -l id"
           localization_branch_name: "l10n_crowdin_android_${{ github.ref_name }}"
           create_pull_request: true
           pull_request_title: "Localization: Update Android Translations (${{ github.ref_name }})"

--- a/crowdin-configs/android.yml
+++ b/crowdin-configs/android.yml
@@ -12,6 +12,8 @@ languages_mapping:
     fa: fa
     fr: fr
     hi: hi
+    id: in
+    it: it
     pt-BR: pt-rBR
     ru: ru
     tr: tr
@@ -29,6 +31,8 @@ languages_mapping:
     fa: fa
     fr: fr-FR
     hi: hi-IN
+    id: id
+    it: it-IT
     pt-BR: pt-BR
     ru: ru-RU
     tr: tr-TR

--- a/nym-vpn-android/buildSrc/src/main/kotlin/Extensions.kt
+++ b/nym-vpn-android/buildSrc/src/main/kotlin/Extensions.kt
@@ -49,6 +49,8 @@ fun Project.languageList(): List<String> {
 		"fa",      // Persian
 		"fr",      // French
 		"hi",      // Hindi
+		"in",      // Indonesian (legacy Java code → values-in)
+		"it",      // Italian
 		"pt-rBR",  // Portuguese (Brazil)
 		"ru",      // Russian
 		"tr",      // Turkish

--- a/nym-vpn-app/src/i18n/config.ts
+++ b/nym-vpn-app/src/i18n/config.ts
@@ -35,6 +35,8 @@ export const languages = [
   { code: 'es', name: 'Español' },
   { code: 'fr', name: 'Français' },
   { code: 'hi', name: 'हिन्दी' },
+  { code: 'id', name: 'Bahasa Indonesia' },
+  { code: 'it', name: 'Italiano' },
   { code: 'pt', name: 'Português Brasileiro' },
   { code: 'ru', name: 'Русский язык' },
   { code: 'tr', name: 'Türkçe' },
@@ -46,7 +48,6 @@ export const languages = [
   // { code: 'cs', name: 'Čeština (Czech)' },
   // { code: 'hu', name: 'Magyar (Hungarian)' },
   // { code: 'el', name: 'ελληνικά' },
-  // { code: 'it', name: 'Italiano' },
   // { code: 'ja', name: '日本語' },
 ] as const;
 

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -27,6 +27,8 @@ import 'dayjs/locale/en';
 import 'dayjs/locale/es';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/hi';
+import 'dayjs/locale/id';
+import 'dayjs/locale/it';
 import 'dayjs/locale/pt';
 import 'dayjs/locale/ru';
 import 'dayjs/locale/tr';

--- a/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
+++ b/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
@@ -759,6 +759,8 @@
 				"zh-Hant",
 				de,
 				hi,
+				id,
+				it,
 				fa,
 				es,
 				tr,


### PR DESCRIPTION
Register it (Italian) and id (Indonesian) in the Tauri, Android and Apple clients and wire the Crowdin configs. Android uses the legacy 'in' resource qualifier for Indonesian (Java's deprecated code; folder values-in); Tauri/Apple use modern 'id'. Strings sync from Crowdin; locales fall back to English until then.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6327)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Italian and Indonesian language support across the Android, desktop, and Apple apps.
  - Italian and Indonesian translations are now included in Android downloads.
  - Added locale support for date and time formatting.
  - Added Italian and Indonesian app-store metadata localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->