### PR TITLE
[Android] Add error handling for Connect button

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profiles: UI and logic (https://github.com/nymtech/nym-vpn-client/pull/6144)
 - Set geo location for android command sender (https://github.com/nymtech/nym-vpn-client/pull/6144)
 - Log prior process exit reasons on startup (https://github.com/nymtech/nym-vpn-client/pull/6236)
+- Add error handling for Connect button (http://github.com/nymtech/nym-vpn-client/pull/6329)
 
 ### Changed
 - Remove score placeholder. Update animation (https://github.com/nymtech/nym-vpn-client/pull/6231)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/Alert.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/Alert.kt
@@ -123,7 +123,7 @@ private fun Alert(message: AlertMessage, onDismiss: () -> Unit, modifier: Modifi
 						)
 					}
 				}
-				if (!isError) {
+				if (message.dismissable) {
 					IconButton(
 						onClick = onDismiss,
 						modifier = Modifier.size(24.dp),

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/AlertController.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/AlertController.kt
@@ -23,6 +23,7 @@ data class AlertMessage(
 	val duration: Long = 4_000L,
 	val onDismiss: (() -> Unit)? = null,
 	val id: AlertId? = null,
+	val dismissable: Boolean = type != AlertType.Error,
 )
 
 data class AlertAction(val label: String, val onClick: () -> Unit)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainAlerts.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainAlerts.kt
@@ -116,6 +116,7 @@ fun MainAlerts(
 					action = AlertAction(retryLabel) { onRetryConnect() },
 					duration = Long.MAX_VALUE,
 					id = AlertId.ConnectionError,
+					dismissable = true,
 				),
 			)
 			is ConnectionState.StartFailure -> AlertController.show(
@@ -125,6 +126,7 @@ fun MainAlerts(
 					action = AlertAction(retryLabel) { onRetryConnect() },
 					duration = Long.MAX_VALUE,
 					id = AlertId.ConnectionError,
+					dismissable = true,
 				),
 			)
 			else -> AlertController.dismiss(id = AlertId.ConnectionError)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -240,7 +240,7 @@ constructor(
 				ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
 		}
 
-		return when (val event = managerState.backendUiEvent) {
+		val resolved = when (val event = managerState.backendUiEvent) {
 			is BackendUiEvent.BandwidthAlert, null -> baseState
 			is BackendUiEvent.Failure -> {
 				if (event.reason is ErrorStateReason.NeedsRelaxedIndependenceCriteria) {
@@ -256,6 +256,15 @@ constructor(
 			}
 			is BackendUiEvent.StartFailure -> ConnectionState.StartFailure(event.exception)
 		}
+
+		Timber.tag(TAG).d(
+			"resolveConnectionState tunnelState=%s backendUiEvent=%s -> %s",
+			managerState.tunnelState,
+			managerState.backendUiEvent,
+			resolved,
+		)
+
+		return resolved
 	}
 
 	private fun handleTunnelStateChange(tunnelState: Tunnel.State, connectedAt: Long?) {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
@@ -131,8 +131,11 @@ internal fun ActionButton(
 					shape = buttonShape,
 				)
 				else -> MainStyledButton(
-					onClick = { onAction(if (isMnemonicStored) ConnectAction.CONNECT else ConnectAction.GET_STARTED) },
-					content = { Text(stringResource(if (isMnemonicStored) R.string.connect else R.string.get_started), style = CustomTypography.buttonMain) },
+					onClick = { onAction(ConnectAction.DISCONNECT) },
+					textColor = MaterialTheme.colorScheme.error,
+					content = { Text(stringResource(R.string.disconnect), style = CustomTypography.buttonMain) },
+					color = Color.Transparent,
+					borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
 					modifier = buttonModifier,
 					shape = buttonShape,
 				)
@@ -140,8 +143,11 @@ internal fun ActionButton(
 		}
 
 		is ConnectionState.StartFailure -> MainStyledButton(
-			onClick = { onAction(ConnectAction.CONNECT) },
-			content = { Text(stringResource(R.string.connect), style = CustomTypography.buttonMain) },
+			onClick = { onAction(ConnectAction.DISCONNECT) },
+			textColor = MaterialTheme.colorScheme.error,
+			content = { Text(stringResource(R.string.disconnect), style = CustomTypography.buttonMain) },
+			color = Color.Transparent,
+			borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
 			modifier = buttonModifier,
 			shape = buttonShape,
 		)

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -227,6 +227,7 @@ class VpnCoreController(
 
 	private fun handleTunnelState(event: TunnelEvent.NewState) {
 		val coarse = event.asTunnelState()
+		Timber.tag(TAG).d("handleTunnelState raw=%s coarse=%s", event.v1, coarse)
 		if (coarse != state) publishState(coarse)
 
 		when (val ts = event.v1) {


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Allow user to disconnect when connection in error state.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
<img width="360" height="808" alt="Screenshot_20260910_112321" src="https://github.com/user-attachments/assets/c0c7ea4b-a13b-40f2-96c1-bd6acc324973" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6329)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection error and startup failure alerts can now be dismissed when appropriate.
  * Error states now present a clear “Disconnect” action instead of offering an unavailable connection action.
  * Improved handling of connection-state transitions provides more consistent behavior during failed connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->