### PR TITLE
Cherry-pick: Go back to 10 second timeout for wg handshake (#6336)

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -385,8 +385,8 @@ async fn wait_for_handshake(
     /// declared unreachable. wireguard-go retransmits the initiation every 5s, so this covers the
     /// first retransmission plus a generous round trip, while still failing a dead entry (e.g. its
     /// WG port blackholed on this network) in a fraction of the exit handshake + metadata windows.
-    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(7);
-    const POLL_INTERVAL: Duration = Duration::from_millis(250);
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
     let started = std::time::Instant::now();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6338)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN connection monitoring by allowing more time for the initial handshake.
  * Reduced the frequency of connection status checks during handshake establishment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->