### PR TITLE
Fix 2-hop connect failures on cellular

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix iOS 2-hop connect failures on cellular: start the connection monitor before the entry-handshake gate so its probes drive the WireGuard handshake, and ignore probe verdicts produced during that warm-up so a slow-but-healthy path is not torn down. A genuinely dead entry still fails fast (https://github.com/nymtech/nym-vpn-client/pull/6308)
 - Bump nym `vpn/release/2026.14-amsterdam` to include LP registration clock-skew stamps (https://github.com/nymtech/nym/pull/7150)
 - [macOS] After disconnect, restore DNS and the physical default route and do not re-apply the kill-switch when already disconnected. (https://github.com/nymtech/nym-vpn-client/pull/6261)
 - Apply the kill-switch when Connect is pressed while still offline. (https://github.com/nymtech/nym-vpn-client/pull/6265)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -855,10 +855,16 @@ impl TunnelMonitor {
             tracing::warn!("Interface up reply timeout");
         }
 
-        // The firewall now allows traffic through the tunnel. First make sure the entry hop
-        // answers at all: an entry whose handshake never completes is dead from this network
-        // regardless of the exit, so it is failed fast and blamed alone instead of waiting out
-        // the exit handshake and metadata windows and blacklisting the exit first.
+        // Start the monitor before the gate so its probes drive the handshake, else the gate
+        // times out on a healthy entry (seen on cellular).
+        let (tunnel_connection_monitor_tx, mut tunnel_connection_monitor_rx) =
+            mpsc::unbounded_channel();
+        let tunnel_connection_monitor_handle = self.create_tunnel_connection_monitor(
+            tunnel_interface.exit_tunnel_metadata(),
+            tunnel_connection_monitor_tx,
+        )?;
+
+        // An entry that never handshakes even while probed is dead; blame it alone.
         let exit_handshake_completed = if let Some(wg_handle) = tunnel_handle.as_wireguard() {
             tracing::debug!("Waiting for entry WireGuard handshake to complete");
             let entry_outcome =
@@ -875,7 +881,7 @@ impl TunnelMonitor {
                     });
                     return Ok(Self::await_shutdown(
                         wg_tunnel_runtime,
-                        None,
+                        Some(tunnel_connection_monitor_handle),
                         tunnel_handle,
                         shutdown_guard,
                     )
@@ -884,7 +890,7 @@ impl TunnelMonitor {
                 HandshakeWaitOutcome::Cancelled => {
                     return Ok(Self::await_shutdown(
                         wg_tunnel_runtime,
-                        None,
+                        Some(tunnel_connection_monitor_handle),
                         tunnel_handle,
                         shutdown_guard,
                     )
@@ -962,13 +968,6 @@ impl TunnelMonitor {
             .unwrap_or(Fuse::terminated());
         let mut mixnet_monitoring_token = pin!(mixnet_monitoring_token);
 
-        let (tunnel_connection_monitor_tx, mut tunnel_connection_monitor_rx) =
-            mpsc::unbounded_channel();
-        let tunnel_connection_monitor_handle = self.create_tunnel_connection_monitor(
-            tunnel_interface.exit_tunnel_metadata(),
-            tunnel_connection_monitor_tx,
-        )?;
-
         let mut last_connection_status = None;
         let mut has_sent_up_event = false;
         let mut ping_viable = false;
@@ -984,6 +983,9 @@ impl TunnelMonitor {
             tunnel: tunnel_conn_data,
         });
 
+        // Ignore non-viable probe verdicts produced during the pre-gate warm-up above.
+        let monitoring_started_at = tokio::time::Instant::now();
+
         loop {
             tokio::select! {
                 event = tunnel_connection_monitor_rx.recv() => {
@@ -991,6 +993,11 @@ impl TunnelMonitor {
                         tracing::info!("Event channel with connection monitor is closed");
                         break;
                     };
+                    if event.status != ConnectionStatusEvent::Viable
+                        && event.end_timestamp < monitoring_started_at
+                    {
+                        continue;
+                    }
                     // Prevent repeated messages
                     if last_connection_status != Some(event.status) {
                         last_connection_status = Some(event.status);


### PR DESCRIPTION
## Description

- Start the connection monitor before the entry-handshake gate so its probe traffic drives the WireGuard handshake, instead of the gate timing out on a healthy gateway before any tunnel traffic exists. This was the cause of connections working instantly on WiFi but failing on 5G/LTE.
- Ignore connection-monitor verdicts produced during that pre-gate warm-up, so a slow-but-healthy cellular path is not torn down by a stale probe failure. A genuinely dead entry gateway still fails fast and is blamed alone.
- Ensure the connection monitor is stopped cleanly if the entry handshake gate times out or is cancelled.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6339)
<!-- Reviewable:end -->
