### PR TITLE
CI: fix iOS and/or Android (Play) only releases

### DIFF
--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -590,16 +590,34 @@ jobs:
             )
           fi
 
+          HAS_FILES=$([ ${#FILES[@]} -gt 0 ] && echo "true" || echo "false")
+          echo "has_files=${HAS_FILES}" >> $GITHUB_OUTPUT
+
           if [ ${#FILES[@]} -gt 0 ]; then
             FILES+=("$CHECKSUM_FILE")
             printf "%s\n" "${FILES[@]}" > "${{ env.RELEASE_ASSETS }}"
           else
-            echo "::error::No files to upload"
-            exit 1
+            echo "::notice::No artifacts for upload."
           fi
+
+      - name: Check assets
+        if: ${{ steps.assets.outputs.has_files != 'true' }}
+        env:
+          HAS_FILES: ${{ steps.assets.outputs.has_files }}
+          PUBLISH_GITHUB: ${{ inputs.publish_github == true }}
+          PUBLISH_S3: ${{ inputs.publish_s3 == true }}
+        run: |
+            if [[ "$PUBLISH_GITHUB" = true ]]; then
+              echo "::warn::Github release will be skipped due to absence of artifacts suitable for directly downloadable release."
+            fi
+
+            if [[ "$PUBLISH_S3" = true ]]; then
+              echo "::warn::Garage/S3 upload will be skipped due to absence of artifacts suitable for directly downloadable release."
+            fi
 
       - name: Upload release assets list
         uses: actions/upload-artifact@v7.0.1
+        if: ${{ steps.assets.outputs.has_files == 'true' }}
         with:
           name: ${{ env.RELEASE_ASSETS_ARTIFACT }}
           path: ${{ env.RELEASE_ASSETS }}
@@ -607,7 +625,7 @@ jobs:
       - name: Publish GitHub Release
         working-directory: ${{ env.OUTPUT_DIR }}
         id: gh-release
-        if: ${{ inputs.publish_github == true }}
+        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TYPE: ${{ needs.resolve.outputs.github_release_type }}
@@ -653,7 +671,7 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
       - name: List asset URLs
-        if: ${{ inputs.publish_github == true }}
+        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.gh-release.outputs.release_tag }}
@@ -662,13 +680,14 @@ jobs:
 
       - name: Upload release payload
         uses: actions/upload-artifact@v7.0.1
+        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
         with:
           name: ${{ env.RELEASE_PAYLOAD_ARTIFACT }}
           path: ${{ env.RELEASE_PAYLOAD }}
 
       - name: Extract asset URLs
         id: extract_urls
-        if: ${{ inputs.publish_github == true }}
+        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
         env:
           GITHUB_RELEASE_URL: ${{ steps.gh-release.outputs.release_url }}
           LINUX_INSTALL: ${{ needs.resolve-artifacts.outputs.linux_install }}
@@ -782,7 +801,7 @@ jobs:
           fi
 
       - name: Prepare S3 manifest
-        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' }}
+        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' && steps.assets.outputs.has_files == 'true' }}
         env:
           BUILD_TIMESTAMP: ${{ inputs.build_timestamp }}
           GITHUB_BRANCH: ${{ inputs.github_branch }}
@@ -802,7 +821,7 @@ jobs:
           cp "$LATEST_MANIFEST_PATH" "$BRANCH_MANIFEST"
 
       - name: Publish release to S3
-        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' }}
+        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' && steps.assets.outputs.has_files == 'true' }}
         uses: ./.github/actions/push-to-s3
         with:
           source_path: ci-builds/

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -590,30 +590,16 @@ jobs:
             )
           fi
 
-          HAS_FILES=$([ ${#FILES[@]} -gt 0 ] && echo "true" || echo "false")
-          echo "has_files=${HAS_FILES}" >> $GITHUB_OUTPUT
-
           if [ ${#FILES[@]} -gt 0 ]; then
             FILES+=("$CHECKSUM_FILE")
             printf "%s\n" "${FILES[@]}" > "${{ env.RELEASE_ASSETS }}"
           else
-            echo "::notice::No artifacts for upload."
+            echo "::warning::No files for upload. Github release may be created without any files attached!"
             echo -n "" > "${{ env.RELEASE_ASSETS }}"
-          fi
-
-      - name: Check assets
-        if: ${{ steps.assets.outputs.has_files != 'true' }}
-        env:
-          HAS_FILES: ${{ steps.assets.outputs.has_files }}
-          PUBLISH_GITHUB: ${{ inputs.publish_github == true }}
-        run: |
-          if [[ "$PUBLISH_GITHUB" = true ]]; then
-            echo "::warn::Github release will be skipped due to absence of files to attach to release."
           fi
 
       - name: Upload release assets list
         uses: actions/upload-artifact@v7.0.1
-        if: ${{ steps.assets.outputs.has_files == 'true' }}
         with:
           name: ${{ env.RELEASE_ASSETS_ARTIFACT }}
           path: ${{ env.RELEASE_ASSETS }}
@@ -621,7 +607,7 @@ jobs:
       - name: Publish GitHub Release
         working-directory: ${{ env.OUTPUT_DIR }}
         id: gh-release
-        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_github == true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TYPE: ${{ needs.resolve.outputs.github_release_type }}
@@ -667,7 +653,7 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
       - name: List asset URLs
-        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_github == true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.gh-release.outputs.release_tag }}
@@ -676,14 +662,14 @@ jobs:
 
       - name: Upload release payload
         uses: actions/upload-artifact@v7.0.1
-        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_github == true }}
         with:
           name: ${{ env.RELEASE_PAYLOAD_ARTIFACT }}
           path: ${{ env.RELEASE_PAYLOAD }}
 
       - name: Extract asset URLs
         id: extract_urls
-        if: ${{ inputs.publish_github == true && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_github == true }}
         env:
           GITHUB_RELEASE_URL: ${{ steps.gh-release.outputs.release_url }}
           LINUX_INSTALL: ${{ needs.resolve-artifacts.outputs.linux_install }}

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -598,6 +598,7 @@ jobs:
             printf "%s\n" "${FILES[@]}" > "${{ env.RELEASE_ASSETS }}"
           else
             echo "::notice::No artifacts for upload."
+            echo -n "" > "${{ env.RELEASE_ASSETS }}"
           fi
 
       - name: Check assets
@@ -605,15 +606,10 @@ jobs:
         env:
           HAS_FILES: ${{ steps.assets.outputs.has_files }}
           PUBLISH_GITHUB: ${{ inputs.publish_github == true }}
-          PUBLISH_S3: ${{ inputs.publish_s3 == true }}
         run: |
-            if [[ "$PUBLISH_GITHUB" = true ]]; then
-              echo "::warn::Github release will be skipped due to absence of artifacts suitable for directly downloadable release."
-            fi
-
-            if [[ "$PUBLISH_S3" = true ]]; then
-              echo "::warn::Garage/S3 upload will be skipped due to absence of artifacts suitable for directly downloadable release."
-            fi
+          if [[ "$PUBLISH_GITHUB" = true ]]; then
+            echo "::warn::Github release will be skipped due to absence of files to attach to release."
+          fi
 
       - name: Upload release assets list
         uses: actions/upload-artifact@v7.0.1
@@ -801,7 +797,7 @@ jobs:
           fi
 
       - name: Prepare S3 manifest
-        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' }}
         env:
           BUILD_TIMESTAMP: ${{ inputs.build_timestamp }}
           GITHUB_BRANCH: ${{ inputs.github_branch }}
@@ -821,7 +817,7 @@ jobs:
           cp "$LATEST_MANIFEST_PATH" "$BRANCH_MANIFEST"
 
       - name: Publish release to S3
-        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' && steps.assets.outputs.has_files == 'true' }}
+        if: ${{ inputs.publish_s3 == true && inputs.github_branch != '' && inputs.build_timestamp != '' }}
         uses: ./.github/actions/push-to-s3
         with:
           source_path: ci-builds/


### PR DESCRIPTION
## Description

Fix error preventing release from proceeding when shipping iOS and/or Android (Play) only release. Empty release will be created on Github if requested. Garage/S3 will contain .aab or .ipa files, although unindexed in manifest file, however manifest file is only used by linux installer script and it doesn't care about neither of those files anyway.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6343)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Releases can now proceed when no files are available to attach, instead of failing during asset preparation.
  - Release payload uploads now occur only when publishing to GitHub is enabled, preventing unintended uploads when that option is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->