### PR TITLE
ci: remove no longer needed call to brew uninstall

### DIFF
--- a/.github/workflows/build-nym-vpn-app-ios.yml
+++ b/.github/workflows/build-nym-vpn-app-ios.yml
@@ -187,7 +187,6 @@ jobs:
           brew install crowdin
           brew install xmlstarlet
           brew install brotli
-          brew uninstall homebrew/core/sentry-cli || true # Tim apple had a different tap with the same name
           brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)

--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -181,7 +181,6 @@ jobs:
           brew install xmlstarlet
           brew install jq
           brew install brotli
-          brew uninstall homebrew/core/sentry-cli || true # Tim apple had a different tap with the same name
           brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)


### PR DESCRIPTION


## Description

`homebrew/core/sentry-cli` is no longer installed on our CI runners.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6345)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS and macOS build processes to install the Sentry command-line tool directly from its designated Homebrew source.
  * Removed the preceding uninstall step from both build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->